### PR TITLE
Code clean-up and wrap-up country information ui

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-12-23T12:41:11.295Z\n"
-"PO-Revision-Date: 2022-12-23T12:41:11.295Z\n"
+"POT-Creation-Date: 2023-01-05T18:40:18.693Z\n"
+"PO-Revision-Date: 2023-01-05T18:40:18.693Z\n"
 
 msgid "Year"
 msgstr ""
@@ -85,6 +85,9 @@ msgid ""
 "for this call"
 msgstr ""
 
+msgid "Country Identification"
+msgstr ""
+
 msgid "Back to Module"
 msgstr ""
 
@@ -142,6 +145,36 @@ msgstr ""
 msgid "HOME"
 msgstr ""
 
+msgid "File Type"
+msgstr ""
+
+msgid "Country"
+msgstr ""
+
+msgid "Batch Id"
+msgstr ""
+
+msgid "Start"
+msgstr ""
+
+msgid "End"
+msgstr ""
+
+msgid "Specimens"
+msgstr ""
+
+msgid "Date"
+msgstr ""
+
+msgid "Filename"
+msgstr ""
+
+msgid "Input Line Nb"
+msgstr ""
+
+msgid "Output Line Nb"
+msgstr ""
+
 msgid "List of Calls"
 msgstr ""
 
@@ -161,4 +194,7 @@ msgid "Hello {{name}}"
 msgstr ""
 
 msgid "Detail page"
+msgstr ""
+
+msgid "Upload History"
 msgstr ""

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2023-01-05T18:40:18.693Z\n"
-"PO-Revision-Date: 2023-01-05T18:40:18.693Z\n"
+"POT-Creation-Date: 2023-01-05T19:11:05.109Z\n"
+"PO-Revision-Date: 2023-01-05T19:11:05.109Z\n"
 
 msgid "Year"
 msgstr ""
@@ -83,9 +83,6 @@ msgstr ""
 msgid ""
 "You need to complete the mandatory uploads before validate the submissions "
 "for this call"
-msgstr ""
-
-msgid "Country Identification"
 msgstr ""
 
 msgid "Back to Module"
@@ -179,6 +176,9 @@ msgid "List of Calls"
 msgstr ""
 
 msgid "All Calls"
+msgstr ""
+
+msgid "Country Information"
 msgstr ""
 
 msgid "2022 Call"

--- a/src/webapp/components/calls-history/CallsHistoryContent.tsx
+++ b/src/webapp/components/calls-history/CallsHistoryContent.tsx
@@ -1,30 +1,17 @@
 import styled from "styled-components";
-import { useAppContext } from "../../contexts/app-context";
-import { CircularProgress, Typography } from "@material-ui/core";
 import { CallsTable } from "./CallsTable";
 import { useLocation } from "react-router-dom";
 import { data } from "./mock-tables-data.json";
-import { useDataSubmissionSteps } from "../../hooks/useDataSubmissionSteps";
 
 export const CallsHistoryContent: React.FC = () => {
-    const { compositionRoot } = useAppContext();
     const location = useLocation();
     const params = new URLSearchParams(location.search);
 
-    const stepsResult = useDataSubmissionSteps(compositionRoot);
-
-    switch (stepsResult.kind) {
-        case "loading":
-            return <CircularProgress />;
-        case "error":
-            return <Typography variant="h6">{stepsResult.message}</Typography>;
-        case "loaded":
-            return (
-                <ContentWrapper>
-                    <CallsTable items={data} data-current-module={params.get("userId")} />
-                </ContentWrapper>
-            );
-    }
+    return (
+        <ContentWrapper>
+            <CallsTable items={data} data-current-module={params.get("userId")} />
+        </ContentWrapper>
+    );
 };
 
 const ContentWrapper = styled.div`

--- a/src/webapp/components/calls-history/CallsTable.tsx
+++ b/src/webapp/components/calls-history/CallsTable.tsx
@@ -18,6 +18,7 @@ export interface CallsTableProps {
     className?: string;
 }
 
+// TODO: replace Table with Datagrid
 export const CallsTable: React.FC<CallsTableProps> = ({ title, items, className }) => {
     return (
         <ContentWrapper className={className}>

--- a/src/webapp/components/country-information/CountryInformationContent.tsx
+++ b/src/webapp/components/country-information/CountryInformationContent.tsx
@@ -1,0 +1,100 @@
+import styled from "styled-components";
+import { CustomCard } from "../custom-card/CustomCard";
+
+// TODO: refactor InfoTable content to json object format and parse rows
+export const CountryInformationContent: React.FC = () => {
+    return (
+        <ContentWrapper>
+            <CustomCard title="Country Identification">
+                <InfoTable>
+                    <tbody>
+                        <tr>
+                            <td>WHO Region</td>
+                            <td>WHO African Region</td>
+                        </tr>
+                        <tr>
+                            <td>Country</td>
+                            <td>Algeria</td>
+                        </tr>
+                        <tr>
+                            <td>Year</td>
+                            <td>2021</td>
+                        </tr>
+                    </tbody>
+                </InfoTable>
+            </CustomCard>
+
+            <CustomCard title="Enrolment Information">
+                <InfoTable>
+                    <tbody>
+                        <tr>
+                            <td>Enrolment status</td>
+                            <td>Yes</td>
+                        </tr>
+                        <tr>
+                            <td>Date of Enrolment</td>
+                            <td>11/06/2019</td>
+                        </tr>
+                    </tbody>
+                </InfoTable>
+            </CustomCard>
+
+            <CustomCard title="Enrolment Information">
+                <InfoTable>
+                    <tbody>
+                        <tr>
+                            <td>Family Name *</td>
+                            <td>Lorem</td>
+                        </tr>
+                        <tr>
+                            <td>First Name *</td>
+                            <td>Ipsum</td>
+                        </tr>
+                        <tr>
+                            <td>Function *</td>
+                            <td>Dolor sit amet</td>
+                        </tr>
+                        <tr>
+                            <td>Email Address *</td>
+                            <td>loremipsum@gmail.com</td>
+                        </tr>
+                        <tr>
+                            <td>Preferred Language (notifications) *</td>
+                            <td>English</td>
+                        </tr>
+                    </tbody>
+                </InfoTable>
+            </CustomCard>
+        </ContentWrapper>
+    );
+};
+
+const ContentWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 40px;
+    max-width: 800px;
+    p.intro {
+        text-align: left;
+        max-width: 730px;
+        margin: 0 auto;
+        font-weight: 300px;
+        line-height: 1.4;
+    }
+`;
+
+const InfoTable = styled.table`
+    border: none;
+    margin: 20px;
+    tr {
+        td {
+            padding: 5px;
+        }
+        td:nth-child(1) {
+            text-align: right;
+        }
+        td:nth-child(2) {
+            font-weight: 600;
+        }
+    }
+`;

--- a/src/webapp/components/country-information/CountryInformationContent.tsx
+++ b/src/webapp/components/country-information/CountryInformationContent.tsx
@@ -39,7 +39,7 @@ export const CountryInformationContent: React.FC = () => {
                 </InfoTable>
             </CustomCard>
 
-            <CustomCard title="Enrolment Information">
+            <CustomCard title="National Focal Point">
                 <InfoTable>
                     <tbody>
                         <tr>

--- a/src/webapp/components/current-call/UploadsTable.tsx
+++ b/src/webapp/components/current-call/UploadsTable.tsx
@@ -21,6 +21,7 @@ export interface UploadsDataProps {
     className?: string;
 }
 
+// TODO: replace Table with Datagrid
 export const UploadsTable: React.FC<UploadsDataProps> = ({ title, items, className }) => {
     return (
         <ContentWrapper className={className}>

--- a/src/webapp/components/custom-card/CustomCard.tsx
+++ b/src/webapp/components/custom-card/CustomCard.tsx
@@ -18,7 +18,7 @@ export const CustomCard: React.FC<CustomCardProps> = ({ minheight, padding, chil
             <Box display="flex" flexDirection="column" justifyContent="space-between" height={"100%"}>
                 {title && (
                     <TitleContainer>
-                        <Typography variant="h5">{i18n.t("Country Identification")}</Typography>
+                        <Typography variant="h5">{i18n.t(title)}</Typography>
                     </TitleContainer>
                 )}
                 {children}

--- a/src/webapp/components/custom-card/CustomCard.tsx
+++ b/src/webapp/components/custom-card/CustomCard.tsx
@@ -1,18 +1,26 @@
 import React from "react";
-import { Box } from "@material-ui/core";
+import { Box, Typography } from "@material-ui/core";
 import { Paper } from "material-ui";
 import styled from "styled-components";
+import { glassColors } from "../../pages/app/themes/dhis2.theme";
+import i18n from "@eyeseetea/d2-ui-components/locales";
 
 interface CustomCardProps {
     minheight?: string;
     height?: string;
     padding?: string;
+    title?: string;
 }
 
-export const CustomCard: React.FC<CustomCardProps> = ({ minheight, padding, children, height = "auto" }) => {
+export const CustomCard: React.FC<CustomCardProps> = ({ minheight, padding, children, height = "auto", title }) => {
     return (
         <StyleCard minheight={minheight} padding={padding} height={height}>
             <Box display="flex" flexDirection="column" justifyContent="space-between" height={"100%"}>
+                {title && (
+                    <TitleContainer>
+                        <Typography variant="h5">{i18n.t("Country Identification")}</Typography>
+                    </TitleContainer>
+                )}
                 {children}
             </Box>
         </StyleCard>
@@ -25,4 +33,11 @@ export const StyleCard = styled(Paper)<CustomCardProps>`
     height: ${props => props.height};
     padding: ${props => props.padding};
     overflow: hidden;
+`;
+
+const TitleContainer = styled.div`
+    background: ${glassColors.mainPrimary};
+    color: white;
+    border-radius: 20px 20px 0px 0px;
+    padding: 14px 34px;
 `;

--- a/src/webapp/components/landing-content/LandingNews.tsx
+++ b/src/webapp/components/landing-content/LandingNews.tsx
@@ -62,6 +62,7 @@ export const LandingNews: React.FC = () => {
     );
 };
 
+// TODO: create reusable custom card with Title prop to prevent repeat of this TitleContainer styled component
 const TitleContainer = styled.div`
     background: ${glassColors.mainPrimary};
     color: white;

--- a/src/webapp/components/landing-content/YourNotifications.tsx
+++ b/src/webapp/components/landing-content/YourNotifications.tsx
@@ -50,6 +50,7 @@ export const YourNotifications: React.FC = () => {
     );
 };
 
+// TODO: create reusable custom card with Title prop to prevent repeat of this TitleContainer styled component
 const TitleContainer = styled.div`
     background: ${glassColors.mainPrimary};
     color: white;

--- a/src/webapp/components/upload-history/UploadHistoryContent.tsx
+++ b/src/webapp/components/upload-history/UploadHistoryContent.tsx
@@ -1,35 +1,22 @@
 import styled from "styled-components";
-import { useAppContext } from "../../contexts/app-context";
-import { CircularProgress, Typography } from "@material-ui/core";
 import { UploadTable } from "./UploadTable";
 import { useLocation } from "react-router-dom";
 import { data } from "./mock-tables-data.json";
-import { useDataSubmissionSteps } from "../../hooks/useDataSubmissionSteps";
 import { Filter } from "./Filter";
 import { CustomCard } from "../custom-card/CustomCard";
 
 export const UploadHistoryContent: React.FC = () => {
-    const { compositionRoot } = useAppContext();
     const location = useLocation();
     const params = new URLSearchParams(location.search);
 
-    const stepsResult = useDataSubmissionSteps(compositionRoot);
-
-    switch (stepsResult.kind) {
-        case "loading":
-            return <CircularProgress />;
-        case "error":
-            return <Typography variant="h6">{stepsResult.message}</Typography>;
-        case "loaded":
-            return (
-                <ContentWrapper>
-                    <Filter />
-                    <CustomCard padding="20px 30px 20px">
-                        <UploadTable items={data} data-current-module={params.get("userId")} />
-                    </CustomCard>
-                </ContentWrapper>
-            );
-    }
+    return (
+        <ContentWrapper>
+            <Filter />
+            <CustomCard padding="20px 30px 20px">
+                <UploadTable items={data} data-current-module={params.get("userId")} />
+            </CustomCard>
+        </ContentWrapper>
+    );
 };
 
 const ContentWrapper = styled.div`

--- a/src/webapp/hooks/useSidebarMenus.tsx
+++ b/src/webapp/hooks/useSidebarMenus.tsx
@@ -51,7 +51,7 @@ export function mapModuleToMenu(module: GlassModule): Menu {
                 kind: "MenuLeaf",
                 level: 0,
                 title: "Country Information",
-                path: "",
+                path: `/country-information/${module.name}`,
             },
         ],
     };

--- a/src/webapp/pages/Router.tsx
+++ b/src/webapp/pages/Router.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { HashRouter, Route, Switch } from "react-router-dom";
 import { CallsHistoryPage } from "./calls-history/CallsHistoryPage";
+import { CountryInformationPage } from "./country-information/CountryInformationPage";
 import { CurrentCallPage } from "./current-call/CurrentCallPage";
 import { DataSubmissionPage } from "./data-submission/DataSubmissionPage";
 import { FakeLandingPage } from "./landing/FakeLandingPage";
@@ -34,6 +35,10 @@ export const Router: React.FC = React.memo(() => {
                 <Route
                     path="/upload-history/:module"
                     render={({ match }) => <UploadHistoryPage moduleName={match.params.module} />}
+                />
+                <Route
+                    path="/country-information/:module"
+                    render={({ match }) => <CountryInformationPage moduleName={match.params.module} />}
                 />
 
                 <Route render={() => <FakeLandingPage />} />

--- a/src/webapp/pages/calls-history/CallsHistoryPage.tsx
+++ b/src/webapp/pages/calls-history/CallsHistoryPage.tsx
@@ -27,6 +27,7 @@ export const CallsHistoryPage: React.FC<CallsHistoryPageProps> = React.memo(({ m
 export const CallsHistoryPageContent: React.FC<CallsHistoryPageProps> = React.memo(({ moduleName }) => {
     const { compositionRoot } = useAppContext();
 
+    // TODO: replace useGlassModule (or parameters) with actual hook to fetch calls history data
     const result = useGlassModule(compositionRoot, moduleName);
 
     const handleClick = (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
@@ -42,6 +43,7 @@ export const CallsHistoryPageContent: React.FC<CallsHistoryPageProps> = React.me
             return (
                 <ContentWrapper>
                     <PreContent>
+                        {/* // TODO: replace this with a global reusable StyledBreadCrumbs component */}
                         <StyledBreadCrumbs aria-label="breadcrumb" separator="">
                             <Button
                                 component={NavLink}

--- a/src/webapp/pages/calls-history/CallsHistoryPage.tsx
+++ b/src/webapp/pages/calls-history/CallsHistoryPage.tsx
@@ -54,7 +54,7 @@ export const CallsHistoryPageContent: React.FC<CallsHistoryPageProps> = React.me
                                 <span>{moduleName}</span>
                             </Button>
                             <ChevronRightIcon />
-                            <Button component={NavLink} to={`/current-call/${moduleName}`} exact={true}>
+                            <Button component={NavLink} to={`/calls-history/${moduleName}`} exact={true}>
                                 <span>{i18n.t("List of Calls")}</span>
                             </Button>
                         </StyledBreadCrumbs>

--- a/src/webapp/pages/country-information/CountryInformationPage.tsx
+++ b/src/webapp/pages/country-information/CountryInformationPage.tsx
@@ -34,8 +34,8 @@ export const CountryInformationPageContent: React.FC<CountryInformationPageProps
                         <span>{moduleName}</span>
                     </Button>
                     <ChevronRightIcon />
-                    <Button component={NavLink} to={`/current-call/${moduleName}`} exact={true}>
-                        <span>{i18n.t("List of Calls")}</span>
+                    <Button component={NavLink} to={`/country-information/${moduleName}`} exact={true}>
+                        <span>{i18n.t("Country Information")}</span>
                     </Button>
                 </StyledBreadCrumbs>
             </PreContent>

--- a/src/webapp/pages/country-information/CountryInformationPage.tsx
+++ b/src/webapp/pages/country-information/CountryInformationPage.tsx
@@ -1,0 +1,93 @@
+import { Breadcrumbs, Button } from "@material-ui/core";
+import React from "react";
+import styled from "styled-components";
+import { MainLayout } from "../../components/main-layout/MainLayout";
+import { glassColors, palette } from "../app/themes/dhis2.theme";
+import ChevronRightIcon from "@material-ui/icons/ChevronRight";
+import { NavLink } from "react-router-dom";
+import i18n from "@eyeseetea/d2-ui-components/locales";
+import { CountryInformationContent } from "../../components/country-information/CountryInformationContent";
+
+interface CountryInformationPageProps {
+    moduleName: string;
+}
+
+export const CountryInformationPage: React.FC<CountryInformationPageProps> = React.memo(({ moduleName }) => {
+    return (
+        <MainLayout>
+            <CountryInformationPageContent moduleName={moduleName} />
+        </MainLayout>
+    );
+});
+
+export const CountryInformationPageContent: React.FC<CountryInformationPageProps> = React.memo(({ moduleName }) => {
+    const handleClick = (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+        event.preventDefault();
+    };
+
+    return (
+        <ContentWrapper>
+            <PreContent>
+                {/* // TODO: replace this with a global reusable StyledBreadCrumbs component */}
+                <StyledBreadCrumbs aria-label="breadcrumb" separator="">
+                    <Button component={NavLink} to={`/current-call/${moduleName}`} exact={true} onClick={handleClick}>
+                        <span>{moduleName}</span>
+                    </Button>
+                    <ChevronRightIcon />
+                    <Button component={NavLink} to={`/current-call/${moduleName}`} exact={true}>
+                        <span>{i18n.t("List of Calls")}</span>
+                    </Button>
+                </StyledBreadCrumbs>
+            </PreContent>
+
+            <CountryInformationContent />
+        </ContentWrapper>
+    );
+});
+
+const ContentWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+`;
+
+const PreContent = styled.div`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    .info {
+        font-size: 14px;
+        span {
+            opacity: 0.5;
+        }
+        span:nth-child(1) {
+            color: ${glassColors.green};
+            opacity: 1;
+        }
+    }
+`;
+
+const StyledBreadCrumbs = styled(Breadcrumbs)`
+    color: ${glassColors.mainPrimary};
+    font-weight: 400;
+    text-transform: uppercase;
+    li {
+        display: flex;
+        align-items: center;
+        p {
+            padding: 6px 8px;
+        }
+        .MuiButton-root {
+            span {
+                color: ${glassColors.mainPrimary};
+                font-size: 15px;
+            }
+        }
+    }
+    .MuiBreadcrumbs-separator {
+        display: none;
+    }
+    svg {
+        color: ${palette.text.secondary};
+    }
+`;

--- a/src/webapp/pages/current-call/CurrentCallPage.tsx
+++ b/src/webapp/pages/current-call/CurrentCallPage.tsx
@@ -27,6 +27,7 @@ export const CurrentCallPage: React.FC<CurrentCallPageContentProps> = React.memo
 export const CurrentCallPageContent: React.FC<CurrentCallPageContentProps> = React.memo(({ moduleName }) => {
     const { compositionRoot } = useAppContext();
 
+    // TODO: replace useGlassModule (or parameters) with actual hook to fetch current call data
     const result = useGlassModule(compositionRoot, moduleName);
 
     const handleClick = (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
@@ -42,6 +43,7 @@ export const CurrentCallPageContent: React.FC<CurrentCallPageContentProps> = Rea
             return (
                 <ContentWrapper moduleColor={result.data.color}>
                     <PreContent>
+                        {/* // TODO: replace this with a global reusable StyledBreadCrumbs component */}
                         <StyledBreadCrumbs aria-label="breadcrumb" separator="">
                             <Button
                                 component={NavLink}

--- a/src/webapp/pages/data-submission/DataSubmissionPage.tsx
+++ b/src/webapp/pages/data-submission/DataSubmissionPage.tsx
@@ -27,6 +27,7 @@ export const DataSubmissionPage: React.FC<DataSubmissionPageProps> = React.memo(
 export const DataSubmissionPageContent: React.FC<DataSubmissionPageProps> = React.memo(({ moduleName }) => {
     const { compositionRoot } = useAppContext();
 
+    // TODO: replace useGlassModule (or parameters) with actual hook to fetch data submission data
     const result = useGlassModule(compositionRoot, moduleName);
 
     function handleClick(event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) {
@@ -42,6 +43,7 @@ export const DataSubmissionPageContent: React.FC<DataSubmissionPageProps> = Reac
             return (
                 <ContentWrapper>
                     <PreContent>
+                        {/* // TODO: replace this with a global reusable StyledBreadCrumbs component */}
                         <StyledBreadCrumbs aria-label="breadcrumb" separator="">
                             <Button
                                 component={NavLink}

--- a/src/webapp/pages/data-submission/DataSubmissionPage.tsx
+++ b/src/webapp/pages/data-submission/DataSubmissionPage.tsx
@@ -54,7 +54,7 @@ export const DataSubmissionPageContent: React.FC<DataSubmissionPageProps> = Reac
                                 <span>{moduleName}</span>
                             </Button>
                             <ChevronRightIcon />
-                            <Button component={NavLink} to={`/current-call/${moduleName}`} exact={true}>
+                            <Button component={NavLink} to={`/data-submission/${moduleName}`} exact={true}>
                                 <span>{i18n.t("2022 Call")}</span>
                             </Button>
                         </StyledBreadCrumbs>

--- a/src/webapp/pages/upload-history/UploadHistoryPage.tsx
+++ b/src/webapp/pages/upload-history/UploadHistoryPage.tsx
@@ -53,7 +53,7 @@ export const UploadHistoryPageContent: React.FC<UploadHistoryPageProps> = React.
                                 <span>{moduleName} asdd</span>
                             </Button>
                             <ChevronRightIcon />
-                            <Button component={NavLink} to={`/data-submission/${moduleName}`} exact={true}>
+                            <Button component={NavLink} to={`/upload-history/${moduleName}`} exact={true}>
                                 <span>{i18n.t("Upload History")}</span>
                             </Button>
                         </StyledBreadCrumbs>

--- a/src/webapp/pages/upload-history/UploadHistoryPage.tsx
+++ b/src/webapp/pages/upload-history/UploadHistoryPage.tsx
@@ -26,6 +26,7 @@ export const UploadHistoryPage: React.FC<UploadHistoryPageProps> = React.memo(({
 export const UploadHistoryPageContent: React.FC<UploadHistoryPageProps> = React.memo(({ moduleName }) => {
     const { compositionRoot } = useAppContext();
 
+    // TODO: replace useGlassModule (or parameters) with actual hook to fetch upload history data
     const result = useGlassModule(compositionRoot, moduleName);
 
     const handleClick = (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
@@ -41,14 +42,15 @@ export const UploadHistoryPageContent: React.FC<UploadHistoryPageProps> = React.
             return (
                 <ContentWrapper>
                     <PreContent>
+                        {/* // TODO: replace this with a global reusable StyledBreadCrumbs component */}
                         <StyledBreadCrumbs aria-label="breadcrumb" separator="">
                             <Button
                                 component={NavLink}
-                                to={`/data-submission/${moduleName}`}
+                                to={`/current-call/${moduleName}`}
                                 exact={true}
                                 onClick={handleClick}
                             >
-                                <span>{moduleName}</span>
+                                <span>{moduleName} asdd</span>
                             </Button>
                             <ChevronRightIcon />
                             <Button component={NavLink} to={`/data-submission/${moduleName}`} exact={true}>


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** https://app.clickup.com/t/860pe95q5

### :memo: Implementation

- create global reusable card components to display each country info
- few code cleanup from existing components and pages

### :art: Screenshots
![image](https://user-images.githubusercontent.com/7484440/210858892-f9b3fbc2-3a49-40b8-a7d8-8641585a58b9.png)


### :fire: Testing

###: squashed commits

init country information page

doc: todo note

set home link to current-call

add title prop to CustomCard

