### PR TITLE
remove none option & default first available dataset

### DIFF
--- a/src/webapp/components/upload/UploadFiles.tsx
+++ b/src/webapp/components/upload/UploadFiles.tsx
@@ -67,8 +67,10 @@ export const UploadFiles: React.FC<UploadFilesProps> = ({ changeStep }) => {
     }, [batchId, isFileValid]);
 
     useEffect(() => {
-        const batchIds = previousUploads.map(uploads => uploads.batchId);
-        setPreviousUploadsBatchIds([...new Set(batchIds)]);
+        const uniqueBatchIds = [...new Set(previousUploads.map(uploads => uploads.batchId))];
+        setPreviousUploadsBatchIds(uniqueBatchIds);
+        const firstSelectableBatchId = datasetOptions.find(({ value }) => !uniqueBatchIds.includes(value))?.value;
+        setBatchId(firstSelectableBatchId || "");
     }, [previousUploads]);
 
     const changeBatchId = async (event: React.ChangeEvent<{ value: unknown }>) => {
@@ -103,16 +105,8 @@ export const UploadFiles: React.FC<UploadFilesProps> = ({ changeStep }) => {
                         label={i18n.t("Choose a Dataset")}
                         labelId="dataset-label"
                     >
-                        <MenuItem value="">
-                            <em>{i18n.t("None")}</em>
-                        </MenuItem>
                         {datasetOptions.map(({ label, value }) => (
-                            <MenuItem
-                                key={value}
-                                value={value}
-                                hidden={true}
-                                disabled={!!previousUploadsBatchIds.includes(value)}
-                            >
+                            <MenuItem key={value} value={value} disabled={!!previousUploadsBatchIds.includes(value)}>
                                 {i18n.t(label)}
                             </MenuItem>
                         ))}

--- a/src/webapp/components/upload/UploadFiles.tsx
+++ b/src/webapp/components/upload/UploadFiles.tsx
@@ -106,7 +106,7 @@ export const UploadFiles: React.FC<UploadFilesProps> = ({ changeStep }) => {
                         labelId="dataset-label"
                     >
                         {datasetOptions.map(({ label, value }) => (
-                            <MenuItem key={value} value={value} disabled={!!previousUploadsBatchIds.includes(value)}>
+                            <MenuItem key={value} value={value} disabled={previousUploadsBatchIds.includes(value)}>
                                 {i18n.t(label)}
                             </MenuItem>
                         ))}


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes [Remove "None" as an option for BatchID and use Dataset 1 as the default option](https://app.clickup.com/t/860pwnuhk)

### :memo: Implementation

- Remove the "none" option from batchId dropdown and default it to the first available option

### :art: Screenshots
*N/A*

### :fire: Testing
