### PR TITLE
solve bug where x doesnt do anything when there was a bad upload

### DIFF
--- a/src/webapp/components/upload/UploadRis.tsx
+++ b/src/webapp/components/upload/UploadRis.tsx
@@ -71,6 +71,9 @@ export const UploadRis: React.FC<UploadRisProps> = ({ risFile, setRisFile, valid
                         setIsLoading(false);
                     }
                 );
+            } else {
+                setRisFile(null);
+                setIsLoading(false);
             }
         },
         [compositionRoot.glassDocuments, snackbar, setRisFile]

--- a/src/webapp/components/upload/UploadSample.tsx
+++ b/src/webapp/components/upload/UploadSample.tsx
@@ -65,6 +65,9 @@ export const UploadSample: React.FC<UploadSampleProps> = ({ batchId, sampleFile,
                     setIsLoading(false);
                 }
             );
+        } else {
+            setSampleFile(null);
+            setIsLoading(false);
         }
     };
 


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes [[Bug Report] Trying to remove a file before I upload is not working](https://app.clickup.com/t/860q53dcy)

### :memo: Implementation

- I couldn't replicate the error, but I uploaded a file mimicking an error in the upload, tried to remove it and it didn't work, that behaviour is fixed with this PR

### :art: Screenshots
*N/A*

### :fire: Testing
