### PR TITLE
Add validation rules instructions

### DIFF
--- a/src/data/repositories/MetadataDefaultRepository.ts
+++ b/src/data/repositories/MetadataDefaultRepository.ts
@@ -97,6 +97,20 @@ export class MetadataDefaultRepository implements MetadataRepository {
         );
     }
 
+    getValidationRuleInstructions(ids: string[]): FutureData<{ id: string; instruction: string }[]> {
+        return apiToFuture(
+            this.api.models.validationRules.get({
+                fields: {
+                    id: true,
+                    instruction: true,
+                },
+                filter: {
+                    id: { in: ids },
+                },
+            })
+        ).map(res => res.objects);
+    }
+
     private buildCategoryCombo(categoryCombo: D2CategoryCombo): CategoryCombo {
         return {
             id: categoryCombo.id,

--- a/src/domain/repositories/MetadataRepository.ts
+++ b/src/domain/repositories/MetadataRepository.ts
@@ -8,4 +8,5 @@ export interface MetadataRepository {
     getDataSet(id: string): FutureData<DataSet>;
     getCategoryCombination(id: string): FutureData<CategoryCombo>;
     validateDataSet(dataset: string, period: string, orgUnit: string, AOCs: string[]): FutureData<unknown>;
+    getValidationRuleInstructions(ids: string[]): FutureData<{ id: string; instruction: string }[]>;
 }

--- a/src/domain/usecases/data-entry/utils/checkDhis2Validations.ts
+++ b/src/domain/usecases/data-entry/utils/checkDhis2Validations.ts
@@ -2,7 +2,10 @@ import { D2ValidationResponse } from "../../../../data/repositories/MetadataDefa
 import i18n from "../../../../locales";
 import { ConsistencyError } from "../../../entities/data-entry/ImportSummary";
 
-export function checkDhis2Validations(validations: D2ValidationResponse[]): ConsistencyError[] {
+export function checkDhis2Validations(
+    validations: D2ValidationResponse[],
+    rulesInstructions: { id: string; instruction: string }[]
+): ConsistencyError[] {
     const errors = _(
         validations.map(({ validationRuleViolations }) => {
             if (validationRuleViolations.length) {
@@ -10,7 +13,11 @@ export function checkDhis2Validations(validations: D2ValidationResponse[]): Cons
                     return i18n.t(
                         `Validation rule '${(rulesViolation as any).validationRule.name}' violated. Left side value: '${
                             (rulesViolation as any).leftsideValue
-                        }', right side value: '${(rulesViolation as any).rightsideValue}'`
+                        }', right side value: '${(rulesViolation as any).rightsideValue}'. Instructions: ${
+                            rulesInstructions.find(
+                                instruction => instruction.id === (rulesViolation as any).validationRule.id
+                            )?.instruction || "-"
+                        }`
                     );
                 });
             }


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes [Get from the API of validation rules the validation rule instruction and put it in the failure message](https://app.clickup.com/t/860qd0eub)

### :memo: Implementation

- Adapt dhis2 validation logic to fetch all validation rules's instructions that were returned on the validation response and use it on the error messages

### :art: Screenshots

<img width="1124" alt="image" src="https://user-images.githubusercontent.com/44171664/231154205-e01b2f58-a15f-4d4e-94c6-79a13e2d84f5.png">


### :fire: Testing
