### PR TITLE
feat: Restrict open data submissions card on homepage to certain statuses

### DIFF
--- a/src/webapp/hooks/useOpenDataSubmissionsByOrgUnit.ts
+++ b/src/webapp/hooks/useOpenDataSubmissionsByOrgUnit.ts
@@ -12,6 +12,8 @@ type GlassDataSubmissionData = {
     module?: GlassModule;
 };
 
+const openDataSubmissionStatuses = ["NOT_COMPLETED", "COMPLETE", "REJECTED", "UPDATE_REQUEST_ACCEPTED"];
+
 export function useOpenDataSubmissionsByOrgUnit(compositionRoot: CompositionRoot, orgUnit: string) {
     const modules = useGlassModules(compositionRoot);
     const [openDataSubmissions, setOpenDataSubmissions] = useState<GlassDataSubmissionsState>({
@@ -23,12 +25,12 @@ export function useOpenDataSubmissionsByOrgUnit(compositionRoot: CompositionRoot
             compositionRoot.glassDataSubmission.getOpenDataSubmissionsByOU(orgUnit).run(
                 openDataSubmissions => {
                     const submissions = openDataSubmissions
+                        .filter(data => data.module !== undefined && openDataSubmissionStatuses.includes(data.status))
                         .map(openDataSubmission => {
                             const module = modules.data.find(module => openDataSubmission.module === module.id);
 
                             return { dataSubmission: openDataSubmission, module };
-                        })
-                        .filter(data => data.module !== undefined);
+                        });
 
                     setOpenDataSubmissions({ kind: "loaded", data: submissions });
                 },


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes [Open data submissions is showing also approved data submissions](https://app.clickup.com/t/860qk3798)

### :memo: Implementation

- Change openDataSubmissions hook to get only dataSubmissions which statuses are : [NOT_COMPLETED, COMPLETE, REJECTED, UPDATE_REQUEST_ACCEPTED]

### :art: Screenshots
*N/A*

### :fire: Testing
