### PR TITLE
fix: add fix to selects to not add padding on body, on open

### DIFF
--- a/src/webapp/components/app-bar/GlassAppBar.tsx
+++ b/src/webapp/components/app-bar/GlassAppBar.tsx
@@ -131,7 +131,12 @@ export const GlassAppBar: React.FC<GlassAppBarProps> = ({ toggleShowMenu }) => {
                                 <LocationIcon />
                             </IconButton>
                             {currentUser?.userOrgUnitsAccess && (
-                                <Select value={orgUnitName} disableUnderline onChange={changeOrgUnit}>
+                                <Select
+                                    value={orgUnitName}
+                                    disableUnderline
+                                    onChange={changeOrgUnit}
+                                    MenuProps={{ disableScrollLock: true }}
+                                >
                                     {currentUser.userOrgUnitsAccess.map(orgUnit => (
                                         <MenuItem
                                             key={orgUnit.orgUnitId}
@@ -170,6 +175,7 @@ export const GlassAppBar: React.FC<GlassAppBarProps> = ({ toggleShowMenu }) => {
                                     vertical: "top",
                                     horizontal: "left",
                                 }}
+                                disableScrollLock={true}
                             >
                                 <MenuItem onClick={() => handleClose("/user-profile")}>
                                     <ListItemIcon>

--- a/src/webapp/components/data-file-history/Filter.tsx
+++ b/src/webapp/components/data-file-history/Filter.tsx
@@ -70,7 +70,12 @@ export const Filter: React.FC<FilterProps> = ({ year, setYear, status, setStatus
             <Box>
                 <FormControl className={classes.formControl}>
                     <StyledInputLabel id="year-label">{i18n.t("Select Year")}</StyledInputLabel>
-                    <Select labelId="year-label" value={year} onChange={e => setYear(e.target.value as string)}>
+                    <Select
+                        labelId="year-label"
+                        value={year}
+                        onChange={e => setYear(e.target.value as string)}
+                        MenuProps={{ disableScrollLock: true }}
+                    >
                         {yearOptions.map(yearItem => (
                             <MenuItem key={yearItem.value} value={yearItem.value}>
                                 {i18n.t(yearItem.label)}
@@ -85,6 +90,7 @@ export const Filter: React.FC<FilterProps> = ({ year, setYear, status, setStatus
                         value={status}
                         label="Select Status"
                         onChange={e => setStatus(e.target.value as string)}
+                        MenuProps={{ disableScrollLock: true }}
                     >
                         {statusOptions.map(statusItem => (
                             <MenuItem key={statusItem.value} value={statusItem.value}>

--- a/src/webapp/components/upload/UploadFiles.tsx
+++ b/src/webapp/components/upload/UploadFiles.tsx
@@ -272,6 +272,7 @@ export const UploadFiles: React.FC<UploadFilesProps> = ({
                                 onChange={changeBatchId}
                                 label={i18n.t("Choose a Dataset")}
                                 labelId="dataset-label"
+                                MenuProps={{ disableScrollLock: true }}
                             >
                                 {datasetOptions.map(({ label, value }) => (
                                     <MenuItem

--- a/src/webapp/components/user-profile/UserSettingsContent.tsx
+++ b/src/webapp/components/user-profile/UserSettingsContent.tsx
@@ -50,7 +50,11 @@ export const UserSettingsContent: FC<UserSettingsContentProps> = ({ userInformat
                         <tr>
                             <td>{i18n.t("Interface language")}</td>
                             <td>
-                                <Select defaultValue={userInformation.settings.keyUiLocale} disabled>
+                                <Select
+                                    defaultValue={userInformation.settings.keyUiLocale}
+                                    MenuProps={{ disableScrollLock: true }}
+                                    disabled
+                                >
                                     {uiLocalesOptions.map(option => (
                                         <MenuItem key={option.locale} value={option.locale}>
                                             {option.name}
@@ -62,7 +66,11 @@ export const UserSettingsContent: FC<UserSettingsContentProps> = ({ userInformat
                         <tr>
                             <td>{i18n.t("Database language")}</td>
                             <td>
-                                <Select defaultValue={userInformation.settings.keyDbLocale} disabled>
+                                <Select
+                                    defaultValue={userInformation.settings.keyDbLocale}
+                                    MenuProps={{ disableScrollLock: true }}
+                                    disabled
+                                >
                                     {databaseLocalesOptions.map(option => (
                                         <MenuItem key={option.locale} value={option.locale}>
                                             {option.name}
@@ -74,7 +82,11 @@ export const UserSettingsContent: FC<UserSettingsContentProps> = ({ userInformat
                         <tr>
                             <td>{i18n.t("Enable message email notifications")}</td>
                             <td>
-                                <Select defaultValue={userInformation.settings.keyMessageEmailNotification} disabled>
+                                <Select
+                                    defaultValue={userInformation.settings.keyMessageEmailNotification}
+                                    MenuProps={{ disableScrollLock: true }}
+                                    disabled
+                                >
                                     {booleanOptions.map(option => (
                                         <MenuItem key={option.value} value={option.value}>
                                             {option.label}
@@ -86,7 +98,11 @@ export const UserSettingsContent: FC<UserSettingsContentProps> = ({ userInformat
                         <tr>
                             <td>{i18n.t("Enable message SMS notifications")}</td>
                             <td>
-                                <Select defaultValue={userInformation.settings.keyMessageSmsNotification} disabled>
+                                <Select
+                                    defaultValue={userInformation.settings.keyMessageSmsNotification}
+                                    MenuProps={{ disableScrollLock: true }}
+                                    disabled
+                                >
                                     {booleanOptions.map(option => (
                                         <MenuItem key={option.value} value={option.value}>
                                             {option.label}


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes [Dancing dropdowns bug](https://app.clickup.com/t/860q0gexr)

### :memo: Implementation

- Fix selects on open adding padding to body. This solution requires to add the MenuProps for future Selects, since I couldn't find a way to bypass this with css on the MUI theme

### :art: Screenshots

### :fire: Testing
