### PR TITLE
Only delete signals with capture access

### DIFF
--- a/src/webapp/components/signals/SignalTableContent.tsx
+++ b/src/webapp/components/signals/SignalTableContent.tsx
@@ -26,10 +26,12 @@ import { useAppContext } from "../../contexts/app-context";
 import { useCurrentOrgUnitContext } from "../../contexts/current-orgUnit-context";
 import { StyledLoaderContainer } from "../upload/ConsistencyChecks";
 import { CircularProgress } from "material-ui";
+import { useGlassCaptureAccess } from "../../hooks/useGlassCaptureAccess";
 
 export const SignalTableContent: React.FC = () => {
     const { compositionRoot } = useAppContext();
     const { signals, setSignals, refreshSignals } = useSignals();
+    const hasCaptureAccess = useGlassCaptureAccess();
     const history = useHistory();
     const [open, setOpen] = useState(false);
     const [signalToDelete, setSignalToDelete] = useState<Signal>();
@@ -229,7 +231,10 @@ export const SignalTableContent: React.FC = () => {
                                                     </TableCell>
 
                                                     <TableCell style={{ opacity: 0.5 }}>
-                                                        <Button onClick={() => showConfirmationDialog(signal)}>
+                                                        <Button
+                                                            disabled={!hasCaptureAccess}
+                                                            onClick={() => showConfirmationDialog(signal)}
+                                                        >
                                                             <DeleteOutline />
                                                         </Button>
                                                     </TableCell>


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes [EAR data visualizers not to be able to delete signals](https://app.clickup.com/t/860rqem86)

### :memo: Implementation

- Disable delete signal button if the current user doesn't have capture access.

### :video_camera: Screenshots/Screen capture

### :fire: Testing
