### PR TITLE
Feature - Disable delete signal peer orgUnit or above

### DIFF
--- a/src/CompositionRoot.ts
+++ b/src/CompositionRoot.ts
@@ -103,7 +103,7 @@ export function getCompositionRoot(instance: Instance) {
     const eGASPValidationDefaultRepository = new ProgramRulesMetadataDefaultRepository(instance);
     const trackerRepository = new TrackerDefaultRepository(instance);
     const captureFormRepository = new CaptureFormDefaultRepository(api);
-    const signalRepository = new SignalDefaultRepository(dataStoreClient);
+    const signalRepository = new SignalDefaultRepository(dataStoreClient, api);
 
     return {
         instance: getExecute({

--- a/src/data/repositories/SignalDefaultRepository.ts
+++ b/src/data/repositories/SignalDefaultRepository.ts
@@ -1,14 +1,18 @@
 import { Future, FutureData } from "../../domain/entities/Future";
 import { Signal } from "../../domain/entities/Signal";
 import { SignalRepository } from "../../domain/repositories/SignalRepository";
+import { D2Api, Id } from "../../types/d2-api";
+import { apiToFuture } from "../../utils/futures";
 import { DataStoreClient } from "../data-store/DataStoreClient";
 import { DataStoreKeys } from "../data-store/DataStoreKeys";
 
 export class SignalDefaultRepository implements SignalRepository {
-    constructor(private dataStoreClient: DataStoreClient) {}
+    constructor(private dataStoreClient: DataStoreClient, private api: D2Api) {}
 
-    getAll(): FutureData<Signal[]> {
-        return this.dataStoreClient.listCollection<Signal>(DataStoreKeys.SIGNALS);
+    getAll(currentOrgUnitId: Id): FutureData<Signal[]> {
+        return this.dataStoreClient.listCollection<Signal>(DataStoreKeys.SIGNALS).flatMap((signals: Signal[]) => {
+            return this.hasDeletePermission(signals, currentOrgUnitId);
+        });
     }
 
     save(signal: Signal): FutureData<void> {
@@ -37,6 +41,36 @@ export class SignalDefaultRepository implements SignalRepository {
             } else {
                 return Future.error("Signal could not be found");
             }
+        });
+    }
+
+    private hasDeletePermission(signals: Signal[], currentOrgUnitId: string): FutureData<Signal[]> {
+        return apiToFuture(
+            this.api.models.organisationUnits.get({
+                fields: {
+                    id: true,
+                    level: true,
+                },
+                filter: {
+                    id: { in: [...signals.map(signal => signal.orgUnit.id), currentOrgUnitId] },
+                },
+            })
+        ).map(({ objects }) => {
+            const extendedSignals: Signal[] = [];
+            const currentOrgUnit = objects.find(orgUnit => orgUnit.id === currentOrgUnitId);
+            signals.forEach(signal => {
+                const signalOrgUnitLevel = objects.find(orgUnit => orgUnit.id === signal?.orgUnit.id)?.level;
+                if (
+                    signal.orgUnit.id === currentOrgUnitId ||
+                    (signalOrgUnitLevel && currentOrgUnit && signalOrgUnitLevel > currentOrgUnit?.level)
+                ) {
+                    extendedSignals.push({ ...signal, userHasDeletePermission: true });
+                } else {
+                    extendedSignals.push({ ...signal, userHasDeletePermission: false });
+                }
+            });
+
+            return extendedSignals;
         });
     }
 }

--- a/src/domain/entities/Signal.ts
+++ b/src/domain/entities/Signal.ts
@@ -11,6 +11,7 @@ export interface Signal {
     creationDate: string;
     status: SignalStatusTypes;
     statusHistory: SignalStatusHistoryType[];
+    userHasDeletePermission?: boolean;
 }
 
 type SignalStatusHistoryType = {

--- a/src/domain/repositories/SignalRepository.ts
+++ b/src/domain/repositories/SignalRepository.ts
@@ -1,7 +1,8 @@
+import { Id } from "@eyeseetea/d2-api";
 import { FutureData } from "../entities/Future";
 import { Signal } from "../entities/Signal";
 
 export interface SignalRepository {
-    getAll(): FutureData<Signal[]>;
+    getAll(currentOrgUnitId: Id): FutureData<Signal[]>;
     save(signal: Signal): FutureData<void>;
 }

--- a/src/domain/usecases/GetSignalsUseCase.ts
+++ b/src/domain/usecases/GetSignalsUseCase.ts
@@ -1,3 +1,4 @@
+import { Id } from "@eyeseetea/d2-api";
 import { UseCase } from "../../CompositionRoot";
 import { FutureData } from "../entities/Future";
 
@@ -8,7 +9,7 @@ import { SignalRepository } from "../repositories/SignalRepository";
 export class GetSignalsUseCase implements UseCase {
     constructor(private signalRepository: SignalRepository) {}
 
-    public execute(): FutureData<Signal[]> {
-        return this.signalRepository.getAll();
+    public execute(currentOrgUnitId: Id): FutureData<Signal[]> {
+        return this.signalRepository.getAll(currentOrgUnitId);
     }
 }

--- a/src/webapp/components/signals/SignalTableContent.tsx
+++ b/src/webapp/components/signals/SignalTableContent.tsx
@@ -232,7 +232,9 @@ export const SignalTableContent: React.FC = () => {
 
                                                     <TableCell style={{ opacity: 0.5 }}>
                                                         <Button
-                                                            disabled={!hasCaptureAccess}
+                                                            disabled={
+                                                                !hasCaptureAccess || !signal.userHasDeletePermission
+                                                            }
                                                             onClick={() => showConfirmationDialog(signal)}
                                                         >
                                                             <DeleteOutline />

--- a/src/webapp/hooks/useSignals.ts
+++ b/src/webapp/hooks/useSignals.ts
@@ -3,11 +3,15 @@ import { GlassState } from "./State";
 import { useAppContext } from "../contexts/app-context";
 import { Signal } from "../../domain/entities/Signal";
 import { useCurrentUserGroupsAccess } from "./useCurrentUserGroupsAccess";
+import { useCurrentOrgUnitContext } from "../contexts/current-orgUnit-context";
 
 export type SignalsState = GlassState<Signal[]>;
 
 export function useSignals() {
     const { compositionRoot } = useAppContext();
+    const {
+        currentOrgUnitAccess: { orgUnitId },
+    } = useCurrentOrgUnitContext();
     const [signals, setSignals] = React.useState<SignalsState>({
         kind: "loading",
     });
@@ -48,7 +52,7 @@ export function useSignals() {
     );
 
     React.useEffect(() => {
-        compositionRoot.signals.getSignals().run(
+        compositionRoot.signals.getSignals(orgUnitId).run(
             signals => {
                 if (confidentialAccessGroup.kind === "loaded" && readAccessGroup.kind === "loaded") {
                     //1. If the user has confidential user group access show:
@@ -82,6 +86,7 @@ export function useSignals() {
         getSignalsByUserOUAccess,
         getNonConfidentailSignalsByUserOUAccess,
         shouldRefreshSignals,
+        orgUnitId,
     ]);
 
     return { signals, setSignals, refreshSignals };


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes [Avoid a user with capture permissions in EAR to delete a signal from a peer OU or above](https://app.clickup.com/t/860rrn3w6)

### :memo: Implementation

- When fetching signals, add a calculated boolean to the Signals object that disables the deletion if the current user orgUnit is different and it's level above the signal's orgUnit.

### :video_camera: Screenshots/Screen capture

### :fire: Testing
