### PR TITLE
Add new rule higher than to questionnaire and show validation error message

### DIFF
--- a/src/webapp/components/questionnaire/QuestionInput.tsx
+++ b/src/webapp/components/questionnaire/QuestionInput.tsx
@@ -47,6 +47,7 @@ export const QuestionWidget: React.FC<QuestionWidgetProps> = React.memo(props =>
                     onChange={value => onChange(update(question, value))}
                     disabled={disabled}
                     numberType={question.numberType}
+                    validationError={question.validationError}
                 />
             );
         case "text":

--- a/src/webapp/components/questionnaire/widgets/NumberWidget.tsx
+++ b/src/webapp/components/questionnaire/widgets/NumberWidget.tsx
@@ -1,17 +1,24 @@
 import React from "react";
 // @ts-ignore
 import { Input } from "@dhis2/ui";
+import styled from "styled-components";
 import { BaseWidgetProps } from "./BaseWidget";
-import { NumberQuestion, QuestionnaireQuestionM } from "../../../../domain/entities/Questionnaire";
+import {
+    NumberQuestion,
+    QuestionnaireQuestionM,
+    ValidationErrorMessage,
+} from "../../../../domain/entities/Questionnaire";
 import { Maybe } from "../../../../types/utils";
+import { glassColors } from "../../../pages/app/themes/dhis2.theme";
 
 export interface NumberWidgetProps extends BaseWidgetProps<string> {
     value: Maybe<string>;
     numberType: NumberQuestion["numberType"];
+    validationError: Maybe<ValidationErrorMessage>;
 }
 
 const NumberWidget: React.FC<NumberWidgetProps> = props => {
-    const { onChange: onValueChange, value, numberType } = props;
+    const { onChange: onValueChange, value, numberType, validationError } = props;
 
     const [stateValue, setStateValue] = React.useState(value);
     React.useEffect(() => setStateValue(value), [value]);
@@ -39,7 +46,9 @@ const NumberWidget: React.FC<NumberWidgetProps> = props => {
                 onChange={updateState}
                 value={stateValue || ""}
                 disabled={props.disabled}
+                error={validationError !== undefined}
             />
+            <ValidationErrorText>{validationError}</ValidationErrorText>
         </>
     );
 };
@@ -47,3 +56,10 @@ const NumberWidget: React.FC<NumberWidgetProps> = props => {
 const { isValidNumberValue } = QuestionnaireQuestionM;
 
 export default React.memo(NumberWidget);
+
+const ValidationErrorText = styled.p`
+    margin: 0;
+    font-size: 12px;
+    line-height: 14px;
+    color: ${glassColors.negative};
+`;


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes [Questionnaire rules 2](https://app.clickup.com/t/860rzea48)

### :memo: Implementation

- [x] Add new rule to the DataStore > modules > inside AMR questionnaires rules: 
```
          {
            "dataElementCodesLowerToHigher": {
              "AMR_GLASS_ACUTE_CARE_NUMBER": "AMR_AMR_ACUTE_CARE_NUMBER",
              "AMR_GLASS_HOSPITALS_NUMBER": "AMR_AMR_HOSPITALS_NUMBER",
              "AMR_GLASS_INPATIENT_ADM_NUMBER": "AMR_AMR_INPATIENT_ADM_NUMBER",
              "AMR_GLASS_INPATIENT_DAY_NUMBER": "AMR_AMR_INPATIENT_DAY_NUMBER",
              "AMR_GLASS_OUTPATIENT_CONS_NUMBER": "AMR_AMR_OUTPATIENT_CONS_NUMBER"
            },
            "type": "sectionValuesHigherThan"
          }
```

- [x] Show error message when rule is not followed

### :video_camera: Screenshots/Screen capture

[Screencast from 22-11-23 14:30:26.webm](https://github.com/EyeSeeTea/glass-dev/assets/49402898/5c1c3d33-572b-49d4-a96f-3d0c096d7015)

### :fire: Testing
