### PR TITLE
Change rows to products or substances in AMC module

### DIFF
--- a/src/data/repositories/data-entry/AMCProductDataDefaultRepository.ts
+++ b/src/data/repositories/data-entry/AMCProductDataDefaultRepository.ts
@@ -59,7 +59,7 @@ export class AMCProductDataDefaultRepository implements AMCProductDataRepository
 
                 return {
                     isValid: allRawProductColsPresent && allTEIColsPresent ? true : false,
-                    rows: rawProductSheet.rows.length - 2, //two rows for header
+                    rows: teiSheet.rows.length - 1, //one row for header
                     specimens: [],
                 };
             } else

--- a/src/webapp/components/current-data-submission/UploadsTable.tsx
+++ b/src/webapp/components/current-data-submission/UploadsTable.tsx
@@ -28,7 +28,11 @@ export const UploadsTable: React.FC<UploadsTableProps> = ({ title, items, classN
                         <TableRow>
                             <TableCell>{i18n.t("Uploaded")}</TableCell>
                             <TableCell>{i18n.t("Period")}</TableCell>
-                            <TableCell>{i18n.t("Rows")}</TableCell>
+                            {currentModuleAccess.moduleName === "AMC" ? (
+                                <TableCell>{i18n.t("Products/Substances")}</TableCell>
+                            ) : (
+                                <TableCell>{i18n.t("Rows")}</TableCell>
+                            )}
                             <TableCell>{i18n.t("Type")}</TableCell>
                             {moduleProperties.get(currentModuleAccess.moduleName)?.isbatchReq && (
                                 <TableCell>{i18n.t("Batch ID")}</TableCell>

--- a/src/webapp/components/current-data-submission/UploadsTableBody.tsx
+++ b/src/webapp/components/current-data-submission/UploadsTableBody.tsx
@@ -162,9 +162,12 @@ export const UploadsTableBody: React.FC<UploadsTableBodyProps> = ({ rows, refres
                             }).run(
                                 ({ deletePrimaryFileSummary, deleteSecondaryFileSummary }) => {
                                     if (deletePrimaryFileSummary) {
+                                        const itemsDeleted =
+                                            currentModuleAccess.moduleName === "AMC" ? "products" : "rows";
+
                                         let message = `${
                                             primaryFileToDelete?.rows || primaryFileToDelete?.records
-                                        } rows deleted for ${
+                                        } ${itemsDeleted} deleted for ${
                                             moduleProperties.get(currentModuleAccess.moduleName)?.primaryFileType
                                         } file`;
 
@@ -251,9 +254,12 @@ export const UploadsTableBody: React.FC<UploadsTableBodyProps> = ({ rows, refres
                                 .run(
                                     deleteSecondaryFileSummary => {
                                         if (secondaryFileToDelete && deleteSecondaryFileSummary) {
+                                            const itemsDeleted =
+                                                currentModuleAccess.moduleName === "AMC" ? "substances" : "rows";
+
                                             const message = ` ${
                                                 secondaryFileToDelete.rows || secondaryFileToDelete.records
-                                            } rows deleted for ${
+                                            } ${itemsDeleted} deleted for ${
                                                 moduleProperties.get(currentModuleAccess.moduleName)?.secondaryFileType
                                             } file.`;
                                             compositionRoot.glassDocuments

--- a/src/webapp/components/data-file-history/DataFileTable.tsx
+++ b/src/webapp/components/data-file-history/DataFileTable.tsx
@@ -150,7 +150,11 @@ export const DataFileTable: React.FC<DataFileTableProps> = ({ title, items, clas
                                 }}
                             >
                                 <span>
-                                    <Typography variant="caption">{i18n.t("Rows")}</Typography>
+                                    {currentModuleAccess.moduleName === "AMC" ? (
+                                        <Typography variant="caption">{i18n.t("Products/Substances")}</Typography>
+                                    ) : (
+                                        <Typography variant="caption">{i18n.t("Rows")}</Typography>
+                                    )}
                                     {rowsSortDirection === "asc" ? (
                                         <ArrowUpward fontSize="small" />
                                     ) : (


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** [Fix Rows on AMC files](https://app.clickup.com/t/8693g29y4)

### :memo: Implementation

- [ ] Change in file tables from Rows to Products/Substances only in AMC module
- [ ] Fix count of rows in product level excel file to count number of products (first tab) instead of consumption rows (second tab)
- [ ] Change file deleted message in AMC from rows deleted to products or substances deleted (depending on deleted file type)

### :video_camera: Screenshots/Screen capture
![Screenshot from 2024-01-11 11-08-56](https://github.com/EyeSeeTea/glass-dev/assets/49402898/6311e06b-85a5-447a-9899-3bd671135308)
![Screenshot from 2024-01-11 11-09-31](https://github.com/EyeSeeTea/glass-dev/assets/49402898/85fa9099-c495-45e6-91c2-7e178105c9a2)
![Screenshot from 2024-01-11 11-12-33](https://github.com/EyeSeeTea/glass-dev/assets/49402898/3febb43c-b750-4d7d-ac41-165d8a1666b1)
![Screenshot from 2024-01-11 11-19-46](https://github.com/EyeSeeTea/glass-dev/assets/49402898/57a41448-ad8e-417d-adc0-024956844a41)
![Screenshot from 2024-01-11 11-20-14](https://github.com/EyeSeeTea/glass-dev/assets/49402898/27ecf60d-dae1-43e0-b2c7-ca7d2a082d16)
![Screenshot from 2024-01-11 11-22-29](https://github.com/EyeSeeTea/glass-dev/assets/49402898/2980544e-0840-463b-b3be-f5e1dac1acb2)



### :fire: Testing
