### PR TITLE
blocking err on category option combo not found, trim codes on file parsing

### DIFF
--- a/src/domain/usecases/data-entry/amr/ImportSampleFile.ts
+++ b/src/domain/usecases/data-entry/amr/ImportSampleFile.ts
@@ -13,7 +13,7 @@ import {
     getCategoryOptionComboByDataElement,
     getCategoryOptionComboByOptionCodes,
 } from "../utils/getCategoryOptionCombo";
-import { includeBlokingErrors } from "../utils/includeBlockingErrors";
+import { includeBlockingErrors } from "../utils/includeBlockingErrors";
 import { mapDataValuesToImportSummary } from "../utils/mapDhis2Summary";
 import { SampleDataRepository } from "../../../repositories/data-entry/SampleDataRepository";
 import { SampleData } from "../../../entities/data-entry/amr-external/SampleData";
@@ -69,7 +69,7 @@ export class ImportSampleFile {
                                 dataSetCategoryOptionValues
                             );
 
-                            const categoryOptionCombo = getCategoryOptionComboByDataElement(
+                            const { categoryOptionComboId: categoryOptionCombo } = getCategoryOptionComboByDataElement(
                                 dataElement,
                                 dataElement_CC,
                                 risData
@@ -114,7 +114,7 @@ export class ImportSampleFile {
 
                                     const importSummary = mapDataValuesToImportSummary(saveSummary);
 
-                                    const summaryWithConsistencyBlokingErrors = includeBlokingErrors(importSummary, [
+                                    const summaryWithConsistencyBlokingErrors = includeBlockingErrors(importSummary, [
                                         ...batchIdErrors,
                                         ...yearErrors,
                                         ...countryErrors,

--- a/src/domain/usecases/data-entry/utils/getCategoryOptionCombo.tsx
+++ b/src/domain/usecases/data-entry/utils/getCategoryOptionCombo.tsx
@@ -14,13 +14,13 @@ export function getCategoryOptionComboByDataElement(
     // in the metadata we have a category option separate for every category
     // this funcion map the value in the file to the expected in category option
     return dataElement.categoryCombo.id === defaultCategoryCombo
-        ? undefined
+        ? { categoryOptionComboId: "", error: "" }
         : getCategoryOptionComboByOptionCodes(dataElement_CC, [
-              externalData.SPECIMEN,
-              externalData.GENDER.replace("UNK", "UNKG"),
-              externalData.ORIGIN.replace("UNK", "UNKO"),
-              externalData.AGEGROUP.replace("UNK", "UNKA"),
-          ]).categoryOptionComboId;
+              externalData.SPECIMEN.trim(),
+              externalData.GENDER.replace("UNK", "UNKG").trim(),
+              externalData.ORIGIN.replace("UNK", "UNKO").trim(),
+              externalData.AGEGROUP.replace("UNK", "UNKA").trim(),
+          ]);
 }
 
 export function getCategoryOptionComboByOptionCodes(categoryCombo: CategoryCombo, codes: string[]) {
@@ -30,9 +30,7 @@ export function getCategoryOptionComboByOptionCodes(categoryCombo: CategoryCombo
     );
 
     if (!categoryOptionCombo) {
-        const errorMessage = `Combination of antibiotic, pathogen and batchId not found ${
-            categoryCombo.name
-        } for codes: ${codes.join(",")}`;
+        const errorMessage = `Combination of ${categoryCombo.name} not found for codes: "${codes.join(",")}"`;
         return { categoryOptionComboId: "", error: errorMessage };
     }
 

--- a/src/domain/usecases/data-entry/utils/includeBlockingErrors.ts
+++ b/src/domain/usecases/data-entry/utils/includeBlockingErrors.ts
@@ -1,11 +1,11 @@
 import { ConsistencyError, ImportSummary } from "../../../entities/data-entry/ImportSummary";
 
-export function includeBlokingErrors(importSummary: ImportSummary, blokingErrors: ConsistencyError[]): ImportSummary {
-    const status = blokingErrors ? "ERROR" : importSummary.status;
+export function includeBlockingErrors(importSummary: ImportSummary, blockingErrors: ConsistencyError[]): ImportSummary {
+    const status = blockingErrors ? "ERROR" : importSummary.status;
 
     return {
         ...importSummary,
         status,
-        blockingErrors: [...importSummary.blockingErrors, ...blokingErrors],
+        blockingErrors: [...importSummary.blockingErrors, ...blockingErrors],
     };
 }


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/86942fc56, https://app.clickup.com/t/86942fc94


### :memo: Implementation
1. If attributeOptionCombo, categoryOptionCombo are not found, show blocking errors and do not proceed.
2. Trim whitespaces when file parsing for AMR 

### :video_camera: Screenshots/Screen capture

https://github.com/EyeSeeTea/glass-dev/assets/83749675/d67b8ad5-aa5e-4570-a75a-15da5ee88986


### :fire: Testing
