### PR TITLE
feat: add unique product id check for AMC product level data

### DIFF
--- a/src/CompositionRoot.ts
+++ b/src/CompositionRoot.ts
@@ -186,7 +186,8 @@ export function getCompositionRoot(instance: Instance) {
                 glassModuleRepository,
                 instanceRepository,
                 programRulesMetadataDefaultRepository,
-                atcRepository
+                atcRepository,
+                amcProductDataRepository
             ),
             validatePrimaryFile: new ValidatePrimaryFileUseCase(
                 risDataRepository,

--- a/src/data/repositories/data-entry/AMCProductDataDefaultRepository.ts
+++ b/src/data/repositories/data-entry/AMCProductDataDefaultRepository.ts
@@ -208,6 +208,19 @@ export class AMCProductDataDefaultRepository implements AMCProductDataRepository
             .getData();
     }
 
+    public getTrackedEntityProductIdsByOUAndPeriod(orgUnitId: Id, period: string): FutureData<string[]> {
+        return Future.fromPromise(
+            this.getAllProductRegisterAndRawProductConsumptionByPeriodAsync(orgUnitId, period)
+        ).map(trackedEntities => {
+            const productsIds = trackedEntities.map(trackedEntity => {
+                return trackedEntity.attributes?.find(attribute => attribute.attribute === AMR_GLASS_AMC_TEA_PRODUCT_ID)
+                    ?.value;
+            });
+
+            return _(productsIds).compact().value();
+        });
+    }
+
     private mapFromD2ProgramToProductRegisterProgramMetadata(
         program: D2Program | undefined
     ): ProductRegisterProgramMetadata | undefined {

--- a/src/domain/repositories/data-entry/AMCProductDataRepository.ts
+++ b/src/domain/repositories/data-entry/AMCProductDataRepository.ts
@@ -29,4 +29,5 @@ export interface AMCProductDataRepository {
         orgUnitId: Id,
         period: string
     ): FutureData<ProductDataTrackedEntity[]>;
+    getTrackedEntityProductIdsByOUAndPeriod(orgUnitId: Id, period: string): FutureData<string[]>;
 }

--- a/src/domain/usecases/data-entry/ImportPrimaryFileUseCase.tsx
+++ b/src/domain/usecases/data-entry/ImportPrimaryFileUseCase.tsx
@@ -19,6 +19,7 @@ import { GlassModuleDefaultRepository } from "../../../data/repositories/GlassMo
 import { ImportAMCProductLevelData } from "./amc/ImportAMCProductLevelData";
 import { InstanceDefaultRepository } from "../../../data/repositories/InstanceDefaultRepository";
 import { GlassATCDefaultRepository } from "../../../data/repositories/GlassATCDefaultRepository";
+import { AMCProductDataRepository } from "../../repositories/data-entry/AMCProductDataRepository";
 
 export class ImportPrimaryFileUseCase {
     constructor(
@@ -35,7 +36,8 @@ export class ImportPrimaryFileUseCase {
         private glassModuleDefaultRepository: GlassModuleDefaultRepository,
         private instanceRepository: InstanceDefaultRepository,
         private programRulesMetadataRepository: ProgramRulesMetadataRepository,
-        private atcRepository: GlassATCDefaultRepository
+        private atcRepository: GlassATCDefaultRepository,
+        private amcProductRepository: AMCProductDataRepository
     ) {}
 
     public execute(
@@ -116,7 +118,8 @@ export class ImportPrimaryFileUseCase {
                     this.glassUploadsRepository,
                     this.metadataRepository,
                     this.programRulesMetadataRepository,
-                    this.atcRepository
+                    this.atcRepository,
+                    this.amcProductRepository
                 );
 
                 return importAMCProductFile.importAMCProductFile(

--- a/src/domain/usecases/data-entry/amc/ImportAMCProductLevelData.ts
+++ b/src/domain/usecases/data-entry/amc/ImportAMCProductLevelData.ts
@@ -21,6 +21,7 @@ import { ProgramRulesMetadataRepository } from "../../../repositories/program-ru
 import { CustomValidationsAMCProductData } from "./CustomValidationsAMCProductData";
 import { GlassATCDefaultRepository } from "../../../../data/repositories/GlassATCDefaultRepository";
 import moment from "moment";
+import { AMCProductDataRepository } from "../../../repositories/data-entry/AMCProductDataRepository";
 
 export const AMC_PRODUCT_REGISTER_PROGRAM_ID = "G6ChA5zMW9n";
 export const AMC_RAW_PRODUCT_CONSUMPTION_STAGE_ID = "GmElQHKXLIE";
@@ -35,7 +36,8 @@ export class ImportAMCProductLevelData {
         private glassUploadsRepository: GlassUploadsRepository,
         private metadataRepository: MetadataRepository,
         private programRulesMetadataRepository: ProgramRulesMetadataRepository,
-        private atcRepository: GlassATCDefaultRepository
+        private atcRepository: GlassATCDefaultRepository,
+        private amcProductRepository: AMCProductDataRepository
     ) {}
 
     public importAMCProductFile(
@@ -279,7 +281,7 @@ export class ImportAMCProductLevelData {
         const programRuleValidations = new ProgramRuleValidationForBLEventProgram(this.programRulesMetadataRepository);
 
         //3. Run Custom AMC Product Validations
-        const customValidations = new CustomValidationsAMCProductData(this.atcRepository);
+        const customValidations = new CustomValidationsAMCProductData(this.atcRepository, this.amcProductRepository);
 
         return Future.joinObj({
             programRuleValidationResults: programRuleValidations.getValidatedTeisAndEvents(programId, [], teis),


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #?https://app.clickup.com/t/86942pyz3

### :memo: Implementation
Add consistency check for AMC product level data such that
1. Product Id is unique for a given data submission period. i.e. Algeria can have Product1 uploaded across multiple periods.
2.  Product Id is unique for a given data submission OU. i.e. Algeria can have Product1 and Thailand can have Product1.

### :video_camera: Screenshots/Screen capture

https://github.com/EyeSeeTea/glass-dev/assets/83749675/56b7eb71-749d-4b62-aec8-ade560aee904

https://github.com/EyeSeeTea/glass-dev/assets/83749675/acdbf0a4-12b3-42ed-ad92-50ca6bff0054


https://github.com/EyeSeeTea/glass-dev/assets/83749675/be3da154-22b4-45a3-9b37-fd2434ad4bcd




### :fire: Testing
