### PR TITLE
fix: set the event date to 01-01 of period

### DIFF
--- a/src/domain/usecases/data-entry/amr-individual-fungal/ImportRISIndividualFungalFile.ts
+++ b/src/domain/usecases/data-entry/amr-individual-fungal/ImportRISIndividualFungalFile.ts
@@ -22,6 +22,7 @@ export const AMRCandidaProgramStageId = "ysGSonDq9Bc";
 
 const PATIENT_COUNTER_ID = "uSGcLbT5gJJ";
 const PATIENT_ID = "qKWPfeSgTnc";
+const AMR_GLASS_AMR_DET_SAMPLE_DATE = "Xtn5zEL9mGx";
 
 export class ImportRISIndividualFungalFile {
     constructor(
@@ -209,11 +210,10 @@ export class ImportRISIndividualFungalFile {
                     }
                 );
 
-                const occurredAt =
-                    moment(new Date(`${period}-01-01`))
-                        .toISOString()
-                        .split("T")
-                        .at(0) ?? period;
+                const sampleDateStr =
+                    AMRDataStage.find(de => de.dataElement === AMR_GLASS_AMR_DET_SAMPLE_DATE)?.value ??
+                    `01-01-${period}`;
+                const sampleDate = moment(new Date(sampleDateStr)).toISOString().split("T").at(0) ?? period;
 
                 const createdAt = moment(new Date()).toISOString().split("T").at(0) ?? period;
 
@@ -224,7 +224,7 @@ export class ImportRISIndividualFungalFile {
                         programStage: AMRDataProgramStageIdl,
                         orgUnit,
                         dataValues: AMRDataStage,
-                        occurredAt: occurredAt,
+                        occurredAt: sampleDate,
                         status: "COMPLETED",
                     },
                 ];
@@ -238,8 +238,8 @@ export class ImportRISIndividualFungalFile {
                         relationships: [],
                         attributes: attributes,
                         events: events,
-                        enrolledAt: occurredAt,
-                        occurredAt: occurredAt,
+                        enrolledAt: sampleDate,
+                        occurredAt: sampleDate,
                         createdAt: createdAt,
                         createdAtClient: createdAt,
                         updatedAt: createdAt,

--- a/src/domain/usecases/data-entry/amr-individual-fungal/ImportRISIndividualFungalFile.ts
+++ b/src/domain/usecases/data-entry/amr-individual-fungal/ImportRISIndividualFungalFile.ts
@@ -13,6 +13,7 @@ import { mapToImportSummary, uploadIdListFileAndSave } from "../ImportBLTemplate
 import { MetadataRepository } from "../../../repositories/MetadataRepository";
 import { downloadIdsAndDeleteTrackedEntities } from "../amc/ImportAMCProductLevelData";
 import { CustomDataColumns } from "../../../entities/data-entry/amr-individual-fungal-external/RISIndividualFungalData";
+import moment from "moment";
 
 export const AMRIProgramID = "mMAj6Gofe49";
 const AMR_GLASS_AMR_TET_PATIENT = "CcgnfemKr5U";
@@ -75,7 +76,8 @@ export class ImportRISIndividualFungalFile {
                                 orgUnit,
                                 AMRIProgramIDl,
                                 AMRDataProgramStageIdl(),
-                                countryCode
+                                countryCode,
+                                period
                             ).flatMap(entities => {
                                 return this.trackerRepository
                                     .import({ trackedEntities: entities }, action)
@@ -185,7 +187,8 @@ export class ImportRISIndividualFungalFile {
         orgUnit: string,
         AMRIProgramIDl: string,
         AMRDataProgramStageIdl: string,
-        countryCode: string
+        countryCode: string,
+        period: string
     ): FutureData<TrackedEntity[]> {
         return this.trackerRepository.getProgramMetadata(AMRIProgramIDl, AMRDataProgramStageIdl).flatMap(metadata => {
             const trackedEntities = individualFungalDataItems.map(dataItem => {
@@ -206,6 +209,14 @@ export class ImportRISIndividualFungalFile {
                     }
                 );
 
+                const occurredAt =
+                    moment(new Date(`${period}-01-01`))
+                        .toISOString()
+                        .split("T")
+                        .at(0) ?? period;
+
+                const createdAt = moment(new Date()).toISOString().split("T").at(0) ?? period;
+
                 const events: D2TrackerEvent[] = [
                     {
                         program: AMRIProgramIDl,
@@ -213,7 +224,7 @@ export class ImportRISIndividualFungalFile {
                         programStage: AMRDataProgramStageIdl,
                         orgUnit,
                         dataValues: AMRDataStage,
-                        occurredAt: new Date().getTime().toString(),
+                        occurredAt: occurredAt,
                         status: "COMPLETED",
                     },
                 ];
@@ -227,12 +238,12 @@ export class ImportRISIndividualFungalFile {
                         relationships: [],
                         attributes: attributes,
                         events: events,
-                        enrolledAt: new Date().getTime().toString(),
-                        occurredAt: new Date().getTime().toString(),
-                        createdAt: new Date().getTime().toString(),
-                        createdAtClient: new Date().getTime().toString(),
-                        updatedAt: new Date().getTime().toString(),
-                        updatedAtClient: new Date().getTime().toString(),
+                        enrolledAt: occurredAt,
+                        occurredAt: occurredAt,
+                        createdAt: createdAt,
+                        createdAtClient: createdAt,
+                        updatedAt: createdAt,
+                        updatedAtClient: createdAt,
                         status: "COMPLETED",
                         orgUnitName: countryCode,
                         followUp: false,


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #? https://app.clickup.com/t/8693yfefj
-  #8693yfefj

### :memo: Implementation
1. set event date of AMR-I and AMR-F events to sample date column
2. if sample date not found, set to 1st Jan of the period.

IMPORTANT!
This PR should be accompanied by adding AMR_GLASS_AMR_DET_SAMPLE_DATE dataelement to AMR - Individual Program, AMR - data Stage. https://dev.eyeseetea.com/who-dev-238/dhis-web-maintenance/index.html#/edit/programSection/program/mMAj6Gofe49

### :video_camera: Screenshots/Screen capture

<img width="1728" alt="Screenshot 2024-03-26 at 1 37 27 PM" src="https://github.com/EyeSeeTea/glass-dev/assets/83749675/fe799277-4cfe-4a34-af35-9e19082cc3ad">
<img width="1728" alt="Screenshot 2024-03-26 at 1 38 20 PM" src="https://github.com/EyeSeeTea/glass-dev/assets/83749675/40b352a6-2684-4053-90fb-c392161f3fa7">


### :fire: Testing
