### PR TITLE
fix: set status as VALIDATED for all non dry-run modules on import com…

### DIFF
--- a/src/webapp/components/upload/UploadFiles.tsx
+++ b/src/webapp/components/upload/UploadFiles.tsx
@@ -275,6 +275,15 @@ export const UploadFiles: React.FC<UploadFilesProps> = ({
                             () => {},
                             () => {}
                         );
+
+                        if (
+                            !currentModuleProperties?.isDryRunReq &&
+                            importPrimaryFileSummary.blockingErrors.length === 0
+                        )
+                            compositionRoot.glassUploads.setStatus({ id: primaryUploadId, status: "VALIDATED" }).run(
+                                () => {},
+                                () => {}
+                            );
                     }
 
                     setImportLoading(false);
@@ -311,6 +320,19 @@ export const UploadFiles: React.FC<UploadFilesProps> = ({
                     importSubstanceFileSummary => {
                         if (importSubstanceFileSummary) {
                             setPrimaryFileImportSummary(importSubstanceFileSummary);
+                            const secondaryUploadId = localStorage.getItem("secondaryUploadId");
+
+                            if (
+                                !currentModuleProperties?.isDryRunReq &&
+                                importSubstanceFileSummary.blockingErrors.length === 0 &&
+                                secondaryUploadId
+                            )
+                                compositionRoot.glassUploads
+                                    .setStatus({ id: secondaryUploadId, status: "VALIDATED" })
+                                    .run(
+                                        () => {},
+                                        () => {}
+                                    );
                         }
                         setImportLoading(false);
                         changeStep(2);
@@ -341,6 +363,7 @@ export const UploadFiles: React.FC<UploadFilesProps> = ({
         setPrimaryFileImportSummary,
         changeStep,
         setSecondaryFileImportSummary,
+        currentModuleProperties?.isDryRunReq,
     ]);
 
     const continueClick = () => {


### PR DESCRIPTION
…plete

### :pushpin: References

-   **Issue:** Closes #? https://app.clickup.com/t/86947rf9b
- 86947rf9b

### :memo: Implementation
1. Set status as VALIDATED for all modules except AMR-AGG when import is completed.

### :video_camera: Screenshots/Screen capture

https://github.com/EyeSeeTea/glass-dev/assets/83749675/9fed6383-a8d4-4e49-9cad-38d56d226ef5



### :fire: Testing
