### PR TITLE
Fix not able to upload product file in amc when there is an optionset in data entries

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-04-12T05:19:17.327Z\n"
-"PO-Revision-Date: 2024-04-12T05:19:17.327Z\n"
+"POT-Creation-Date: 2024-04-30T07:52:46.176Z\n"
+"PO-Revision-Date: 2024-04-30T07:52:46.176Z\n"
 
 msgid "Template {{id}} not loaded"
 msgstr ""
@@ -598,6 +598,9 @@ msgstr ""
 msgid "Fix upload data"
 msgstr ""
 
+msgid "Select file"
+msgstr ""
+
 msgid "Error fetching previous uploads."
 msgstr ""
 
@@ -620,9 +623,6 @@ msgid "Error in file upload"
 msgstr ""
 
 msgid "Incorrect File Format. Please retry with a valid file"
-msgstr ""
-
-msgid "Select file"
 msgstr ""
 
 msgid "The password and confirm password fields don't match"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2024-04-12T05:19:17.327Z\n"
+"POT-Creation-Date: 2024-04-30T07:52:46.176Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -600,6 +600,9 @@ msgstr ""
 msgid "Fix upload data"
 msgstr ""
 
+msgid "Select file"
+msgstr ""
+
 msgid "Error fetching previous uploads."
 msgstr ""
 
@@ -622,9 +625,6 @@ msgid "Error in file upload"
 msgstr ""
 
 msgid "Incorrect File Format. Please retry with a valid file"
-msgstr ""
-
-msgid "Select file"
 msgstr ""
 
 msgid "The password and confirm password fields don't match"

--- a/src/domain/usecases/data-entry/ImportBLTemplateEventProgram.ts
+++ b/src/domain/usecases/data-entry/ImportBLTemplateEventProgram.ts
@@ -475,7 +475,7 @@ export const formatDhis2Value = (item: DataPackageDataValue, dataForm: DataForm)
         return booleanValue ? { ...item, value: true } : undefined;
     }
 
-    const selectedOption = dataElement?.options?.find(({ id }) => item.value === id);
+    const selectedOption = dataElement?.options?.find(({ id }) => item.optionId === id);
     const value = selectedOption?.code ?? item.value;
     return { ...item, value };
 };


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #8694f2qcg [Not able to upload product file in amc when there is an optionset configured in a data element](https://app.clickup.com/t/8694f2qcg)

### :memo: Implementation
- Fix not able to upload product file in amc when there is an optionset in data entries

### :video_camera: Screenshots/Screen capture
![image](https://github.com/EyeSeeTea/glass-dev/assets/49402898/1c4650f2-88c2-4e50-b3e2-8d2142a13495)
![Screenshot from 2024-04-30 09-37-09](https://github.com/EyeSeeTea/glass-dev/assets/49402898/06dab243-a97f-45f5-a24a-52da94527f8f)

### :fire: Testing
1. Go to Thailand
2. Go to AMC
3. Upload a product file
