### PR TITLE
Changes to the AMC calculations

### DIFF
--- a/src/domain/entities/GlassAtcVersionData.ts
+++ b/src/domain/entities/GlassAtcVersionData.ts
@@ -16,6 +16,8 @@ export type GlassATCRecalculateDataInfo = {
 
 export const LAST_ATC_CODE_LEVEL = 5;
 export const DEFAULT_SALT_CODE = "XXXX";
+export const CODE_PRODUCT_NOT_HAVE_ATC = "Z99ZZ99";
+export const COMB_CODE_PRODUCT_NOT_HAVE_ATC = "Z99ZZ99_99";
 
 export type ATCCodeLevel5 = string;
 

--- a/src/domain/entities/data-entry/amc/ProductRegistryAttributes.ts
+++ b/src/domain/entities/data-entry/amc/ProductRegistryAttributes.ts
@@ -10,7 +10,7 @@ export type ProductRegistryAttributes = {
     AMR_GLASS_AMC_TEA_COMBINATION?: string;
     AMR_GLASS_AMC_TEA_ROUTE_ADMIN: RouteOfAdministrationCode;
     AMR_GLASS_AMC_TEA_SALT: SaltCode;
-    AMR_AMC_TEA_VOLUME: number;
+    AMR_GLASS_AMC_TEA_VOLUME: number;
 };
 
 export const PRODUCT_REGISTRY_ATTRIBUTES_KEYS = [
@@ -23,5 +23,5 @@ export const PRODUCT_REGISTRY_ATTRIBUTES_KEYS = [
     "AMR_GLASS_AMC_TEA_COMBINATION",
     "AMR_GLASS_AMC_TEA_ROUTE_ADMIN",
     "AMR_GLASS_AMC_TEA_SALT",
-    "AMR_AMC_TEA_VOLUME",
+    "AMR_GLASS_AMC_TEA_VOLUME",
 ];

--- a/src/domain/entities/data-entry/amc/RawProductConsumption.ts
+++ b/src/domain/entities/data-entry/amc/RawProductConsumption.ts
@@ -1,6 +1,6 @@
 export type RawProductConsumption = {
     AMR_GLASS_AMC_TEA_PRODUCT_ID: string;
-    packages: number;
+    packages_manual: number;
     data_status_manual: number;
     health_sector_manual: string;
     health_level_manual: string;
@@ -9,7 +9,7 @@ export type RawProductConsumption = {
 export const RAW_PRODUCT_CONSUMPTION_KEYS = [
     "AMR_GLASS_AMC_TEA_PRODUCT_ID",
     "date",
-    "packages",
+    "packages_manual",
     "data_status_manual",
     "health_sector_manual",
     "health_level_manual",

--- a/src/domain/usecases/data-entry/amc/CalculateConsumptionDataProductLevelUseCase.ts
+++ b/src/domain/usecases/data-entry/amc/CalculateConsumptionDataProductLevelUseCase.ts
@@ -1,6 +1,10 @@
 import { Future, FutureData } from "../../../entities/Future";
 import { Id } from "../../../entities/Ref";
-import { createAtcVersionKey } from "../../../entities/GlassAtcVersionData";
+import {
+    CODE_PRODUCT_NOT_HAVE_ATC,
+    COMB_CODE_PRODUCT_NOT_HAVE_ATC,
+    createAtcVersionKey,
+} from "../../../entities/GlassAtcVersionData";
 import { mapToImportSummary, readTemplate } from "../ImportBLTemplateEventProgram";
 import { ExcelRepository } from "../../../repositories/ExcelRepository";
 import { GlassATCRepository } from "../../../repositories/GlassATCRepository";
@@ -20,6 +24,8 @@ import { logger } from "../../../../utils/logger";
 const TEMPLATE_ID = "TRACKER_PROGRAM_GENERATED_v3";
 const IMPORT_SUMMARY_EVENT_TYPE = "event";
 const IMPORT_STRATEGY_CREATE_AND_UPDATE = "CREATE_AND_UPDATE";
+const AMR_GLASS_AMC_TEA_ATC = "aK1JpD14imM";
+const AMR_GLASS_AMC_TEA_COMBINATION = "mG49egdYK3G";
 
 export class CalculateConsumptionDataProductLevelUseCase {
     constructor(
@@ -48,8 +54,17 @@ export class CalculateConsumptionDataProductLevelUseCase {
                     atcVersionHistory: this.atcRepository.getAtcHistory(),
                 });
             })
-            .flatMap(result => {
-                const { productRegisterProgramMetadata, productDataTrackedEntities, atcVersionHistory } = result;
+            .flatMap(({ productRegisterProgramMetadata, productDataTrackedEntities, atcVersionHistory }) => {
+                const validProductDataTrackedEntitiesToCalculate = productDataTrackedEntities.filter(
+                    ({ attributes }) => {
+                        const productWithoutAtcCode = attributes.some(
+                            ({ id, value }) =>
+                                (id === AMR_GLASS_AMC_TEA_ATC && value === CODE_PRODUCT_NOT_HAVE_ATC) ||
+                                (id === AMR_GLASS_AMC_TEA_COMBINATION && value === COMB_CODE_PRODUCT_NOT_HAVE_ATC)
+                        );
+                        return !productWithoutAtcCode;
+                    }
+                );
                 const atcCurrentVersionInfo = atcVersionHistory.find(({ currentVersion }) => currentVersion);
                 if (!atcCurrentVersionInfo) {
                     logger.error(`Cannot find current version of ATC in version history.`);
@@ -65,7 +80,7 @@ export class CalculateConsumptionDataProductLevelUseCase {
                         orgUnitId,
                         period,
                         productRegisterProgramMetadata,
-                        productDataTrackedEntities,
+                        productDataTrackedEntities: validProductDataTrackedEntitiesToCalculate,
                         atcCurrentVersionData,
                         atcVersionKey,
                     }).flatMap(rawSubstanceConsumptionCalculatedData => {
@@ -106,7 +121,7 @@ export class CalculateConsumptionDataProductLevelUseCase {
                         return this.amcProductDataRepository
                             .importCalculations(
                                 IMPORT_STRATEGY_CREATE_AND_UPDATE,
-                                productDataTrackedEntities,
+                                validProductDataTrackedEntitiesToCalculate,
                                 rawSubstanceConsumptionCalculatedStageMetadata,
                                 rawSubstanceConsumptionCalculatedData,
                                 orgUnitId,

--- a/src/domain/usecases/data-entry/amc/CalculateConsumptionDataSubstanceLevelUseCase.ts
+++ b/src/domain/usecases/data-entry/amc/CalculateConsumptionDataSubstanceLevelUseCase.ts
@@ -1,6 +1,6 @@
 import { logger } from "../../../../utils/logger";
 import { Future, FutureData } from "../../../entities/Future";
-import { createAtcVersionKey } from "../../../entities/GlassAtcVersionData";
+import { CODE_PRODUCT_NOT_HAVE_ATC, createAtcVersionKey } from "../../../entities/GlassAtcVersionData";
 import { Id } from "../../../entities/Ref";
 import { ImportSummary } from "../../../entities/data-entry/ImportSummary";
 import { GlassATCRepository } from "../../../repositories/GlassATCRepository";
@@ -41,8 +41,10 @@ export class CalculateConsumptionDataSubstanceLevelUseCase {
                     atcVersionHistory: this.atcRepository.getAtcHistory(),
                 });
             })
-            .flatMap(result => {
-                const { rawSubstanceConsumptionData, atcVersionHistory } = result;
+            .flatMap(({ rawSubstanceConsumptionData, atcVersionHistory }) => {
+                const validRawSubstanceConsumptionData = rawSubstanceConsumptionData?.filter(
+                    ({ atc_manual }) => atc_manual !== CODE_PRODUCT_NOT_HAVE_ATC
+                );
                 const atcCurrentVersionInfo = atcVersionHistory.find(({ currentVersion }) => currentVersion);
                 if (!atcCurrentVersionInfo) {
                     logger.error(`Cannot find current version of ATC in version history.`);
@@ -61,7 +63,7 @@ export class CalculateConsumptionDataSubstanceLevelUseCase {
                         orgUnitId,
                         period,
                         atcRepository: this.atcRepository,
-                        rawSubstanceConsumptionData,
+                        rawSubstanceConsumptionData: validRawSubstanceConsumptionData,
                         currentAtcVersionKey,
                         atcCurrentVersionData,
                     }).flatMap(calculatedConsumptionSubstanceLevelData => {

--- a/src/domain/usecases/data-entry/amc/CustomValidationsAMCProductData.ts
+++ b/src/domain/usecases/data-entry/amc/CustomValidationsAMCProductData.ts
@@ -18,6 +18,8 @@ const atcLevel4WithOralROA3 = "J01XD";
 const atcLevel4WithOralROA4 = "J01XA";
 const atcCodeWithSaltHippAndMand = "J01XX05";
 const atcCodeWithRoaOAndSaltDefault = "J01FA01";
+const CODE_PRODUCT_NOT_HAVE_ATC = "Z99ZZ99";
+const COMB_CODE_PRODUCT_NOT_HAVE_ATC = "Z99ZZ99_99";
 
 export class CustomValidationsAMCProductData {
     constructor(
@@ -144,10 +146,12 @@ export class CustomValidationsAMCProductData {
                 }
                 if (atcCode) {
                     const atcData = atcVersion.atcs;
-                    const isValidATCCode = atcData.find(
-                        data => data.CODE === atcCode && data.LEVEL === LAST_ATC_CODE_LEVEL
-                    );
-                    if (!isValidATCCode) {
+                    const validATCCode =
+                        atcCode === CODE_PRODUCT_NOT_HAVE_ATC
+                            ? atcCode
+                            : atcData.find(data => data.CODE === atcCode && data.LEVEL === LAST_ATC_CODE_LEVEL)?.CODE;
+
+                    if (!validATCCode) {
                         curErrors.push({
                             error: i18n.t(
                                 `ATC code specified in the file is not a valid level 5 ATC code : ${atcCode}`
@@ -173,12 +177,7 @@ export class CustomValidationsAMCProductData {
                             });
                         }
 
-                        if (
-                            isValidATCCode.CODE === atcCodeWithSaltHippAndMand &&
-                            salt &&
-                            salt !== "HIPP" &&
-                            salt !== "MAND"
-                        ) {
+                        if (validATCCode === atcCodeWithSaltHippAndMand && salt && salt !== "HIPP" && salt !== "MAND") {
                             curErrors.push({
                                 error: i18n.t(
                                     `If ATC code is ${atcCodeWithSaltHippAndMand}, salt must be either HIPP or MAND`
@@ -186,7 +185,7 @@ export class CustomValidationsAMCProductData {
                                 line: tei.trackedEntity ? parseInt(tei.trackedEntity) + 6 : -1,
                             });
                         }
-                        if (isValidATCCode.CODE === atcCodeWithRoaOAndSaltDefault) {
+                        if (validATCCode === atcCodeWithRoaOAndSaltDefault) {
                             if (roa && roa === "O" && !(salt === "XXXX" || salt === "ESUC")) {
                                 curErrors.push({
                                     error: i18n.t(
@@ -210,7 +209,7 @@ export class CustomValidationsAMCProductData {
                 const validCombinationCode = combinationData.find(data => data.COMB_CODE === combinationCode);
 
                 if (combinationCode) {
-                    if (!validCombinationCode) {
+                    if (!validCombinationCode && combinationCode !== COMB_CODE_PRODUCT_NOT_HAVE_ATC) {
                         curErrors.push({
                             error: i18n.t(
                                 `Combination code specified in the file is not a valid combination code : ${combinationCode}`
@@ -220,7 +219,7 @@ export class CustomValidationsAMCProductData {
                     }
                 }
 
-                if (roa && validCombinationCode) {
+                if (roa && validCombinationCode && combinationCode !== COMB_CODE_PRODUCT_NOT_HAVE_ATC) {
                     if (roa !== validCombinationCode.ROA) {
                         curErrors.push({
                             error: i18n.t(

--- a/src/domain/usecases/data-entry/amc/RecalculateConsumptionDataSubstanceLevelForAllUseCase.ts
+++ b/src/domain/usecases/data-entry/amc/RecalculateConsumptionDataSubstanceLevelForAllUseCase.ts
@@ -2,7 +2,11 @@ import _ from "lodash";
 import { logger } from "../../../../utils/logger";
 import { Id } from "../../../entities/Ref";
 import { Future, FutureData } from "../../../entities/Future";
-import { DEFAULT_SALT_CODE, GlassAtcVersionData } from "../../../entities/GlassAtcVersionData";
+import {
+    CODE_PRODUCT_NOT_HAVE_ATC,
+    DEFAULT_SALT_CODE,
+    GlassAtcVersionData,
+} from "../../../entities/GlassAtcVersionData";
 import { RawSubstanceConsumptionData } from "../../../entities/data-entry/amc/RawSubstanceConsumptionData";
 import { SubstanceConsumptionCalculated } from "../../../entities/data-entry/amc/SubstanceConsumptionCalculated";
 import { GlassATCRepository } from "../../../repositories/GlassATCRepository";
@@ -182,6 +186,14 @@ export class RecalculateConsumptionDataSubstanceLevelForAllUseCase {
             ),
             currentCalculatedConsumptionData:
                 this.amcSubstanceDataRepository.getAllCalculatedSubstanceConsumptionDataByByPeriod(orgUnitId, period),
+        }).flatMap(({ rawSubstanceConsumptionData, currentCalculatedConsumptionData }) => {
+            const validRawSubstanceConsumptionData = rawSubstanceConsumptionData?.filter(
+                ({ atc_manual }) => atc_manual !== CODE_PRODUCT_NOT_HAVE_ATC
+            );
+            return Future.success({
+                rawSubstanceConsumptionData: validRawSubstanceConsumptionData,
+                currentCalculatedConsumptionData,
+            });
         });
     }
 }

--- a/src/domain/usecases/data-entry/amc/utils/__tests__/data/productRegistryAttributesBasic.json
+++ b/src/domain/usecases/data-entry/amc/utils/__tests__/data/productRegistryAttributesBasic.json
@@ -8,7 +8,7 @@
         "AMR_GLASS_AMC_TEA_ATC": "J01FA01",
         "AMR_GLASS_AMC_TEA_ROUTE_ADMIN": "O",
         "AMR_GLASS_AMC_TEA_SALT": "XXXX",
-        "AMR_AMC_TEA_VOLUME": 1
+        "AMR_GLASS_AMC_TEA_VOLUME": 1
     },
     {
         "AMR_GLASS_AMC_TEA_PRODUCT_ID": "P37",
@@ -19,6 +19,6 @@
         "AMR_GLASS_AMC_TEA_ATC": "A07AA09",
         "AMR_GLASS_AMC_TEA_ROUTE_ADMIN": "O",
         "AMR_GLASS_AMC_TEA_SALT": "XXXX",
-        "AMR_AMC_TEA_VOLUME": 1
+        "AMR_GLASS_AMC_TEA_VOLUME": 1
     }
 ]

--- a/src/domain/usecases/data-entry/amc/utils/__tests__/data/productRegistryAttributesConcVolumeAndVolume.json
+++ b/src/domain/usecases/data-entry/amc/utils/__tests__/data/productRegistryAttributesConcVolumeAndVolume.json
@@ -8,7 +8,7 @@
         "AMR_GLASS_AMC_TEA_ATC": "J01CA04",
         "AMR_GLASS_AMC_TEA_ROUTE_ADMIN": "O",
         "AMR_GLASS_AMC_TEA_SALT": "XXXX",
-        "AMR_AMC_TEA_VOLUME": 100
+        "AMR_GLASS_AMC_TEA_VOLUME": 100
     },
     {
         "AMR_GLASS_AMC_TEA_PRODUCT_ID": "P37",
@@ -19,6 +19,6 @@
         "AMR_GLASS_AMC_TEA_ATC": "J01CA04",
         "AMR_GLASS_AMC_TEA_ROUTE_ADMIN": "O",
         "AMR_GLASS_AMC_TEA_SALT": "XXXX",
-        "AMR_AMC_TEA_VOLUME": 100
+        "AMR_GLASS_AMC_TEA_VOLUME": 100
     }
 ]

--- a/src/domain/usecases/data-entry/amc/utils/__tests__/data/productRegistryAttributesMillionInternationalUnitDifferentDDDUnit.json
+++ b/src/domain/usecases/data-entry/amc/utils/__tests__/data/productRegistryAttributesMillionInternationalUnitDifferentDDDUnit.json
@@ -8,7 +8,7 @@
         "AMR_GLASS_AMC_TEA_ATC": "J01CE01",
         "AMR_GLASS_AMC_TEA_ROUTE_ADMIN": "P",
         "AMR_GLASS_AMC_TEA_SALT": "XXXX",
-        "AMR_AMC_TEA_VOLUME": 1
+        "AMR_GLASS_AMC_TEA_VOLUME": 1
     },
     {
         "AMR_GLASS_AMC_TEA_PRODUCT_ID": "P37",
@@ -19,6 +19,6 @@
         "AMR_GLASS_AMC_TEA_ATC": "J01CE01",
         "AMR_GLASS_AMC_TEA_ROUTE_ADMIN": "P",
         "AMR_GLASS_AMC_TEA_SALT": "XXXX",
-        "AMR_AMC_TEA_VOLUME": 1
+        "AMR_GLASS_AMC_TEA_VOLUME": 1
     }
 ]

--- a/src/domain/usecases/data-entry/amc/utils/__tests__/data/productRegistryAttributesNoCombCodeNoFoundDDD.json
+++ b/src/domain/usecases/data-entry/amc/utils/__tests__/data/productRegistryAttributesNoCombCodeNoFoundDDD.json
@@ -8,7 +8,7 @@
         "AMR_GLASS_AMC_TEA_ATC": "ATC_NOT_IN_atcCurrentVersionData",
         "AMR_GLASS_AMC_TEA_ROUTE_ADMIN": "O",
         "AMR_GLASS_AMC_TEA_SALT": "XXXX",
-        "AMR_AMC_TEA_VOLUME": 1
+        "AMR_GLASS_AMC_TEA_VOLUME": 1
     },
     {
         "AMR_GLASS_AMC_TEA_PRODUCT_ID": "P37",
@@ -19,6 +19,6 @@
         "AMR_GLASS_AMC_TEA_ATC": "ATC_NOT_IN_atcCurrentVersionData",
         "AMR_GLASS_AMC_TEA_ROUTE_ADMIN": "O",
         "AMR_GLASS_AMC_TEA_SALT": "XXXX",
-        "AMR_AMC_TEA_VOLUME": 1
+        "AMR_GLASS_AMC_TEA_VOLUME": 1
     }
 ]

--- a/src/domain/usecases/data-entry/amc/utils/__tests__/data/productRegistryAttributesUnitDoseCombCode.json
+++ b/src/domain/usecases/data-entry/amc/utils/__tests__/data/productRegistryAttributesUnitDoseCombCode.json
@@ -9,7 +9,7 @@
         "AMR_GLASS_AMC_TEA_COMBINATION": "J01EE01_3",
         "AMR_GLASS_AMC_TEA_ROUTE_ADMIN": "O",
         "AMR_GLASS_AMC_TEA_SALT": "XXXX",
-        "AMR_AMC_TEA_VOLUME": 1
+        "AMR_GLASS_AMC_TEA_VOLUME": 1
     },
     {
         "AMR_GLASS_AMC_TEA_PRODUCT_ID": "P37",
@@ -21,6 +21,6 @@
         "AMR_GLASS_AMC_TEA_COMBINATION": "J01EE01_3",
         "AMR_GLASS_AMC_TEA_ROUTE_ADMIN": "O",
         "AMR_GLASS_AMC_TEA_SALT": "XXXX",
-        "AMR_AMC_TEA_VOLUME": 1
+        "AMR_GLASS_AMC_TEA_VOLUME": 1
     }
 ]

--- a/src/domain/usecases/data-entry/amc/utils/__tests__/data/productRegistryAttributesWrongStrengthUnit.json
+++ b/src/domain/usecases/data-entry/amc/utils/__tests__/data/productRegistryAttributesWrongStrengthUnit.json
@@ -8,7 +8,7 @@
         "AMR_GLASS_AMC_TEA_ATC": "J01FA01",
         "AMR_GLASS_AMC_TEA_ROUTE_ADMIN": "O",
         "AMR_GLASS_AMC_TEA_SALT": "XXXX",
-        "AMR_AMC_TEA_VOLUME": 1
+        "AMR_GLASS_AMC_TEA_VOLUME": 1
     },
     {
         "AMR_GLASS_AMC_TEA_PRODUCT_ID": "P37",
@@ -19,6 +19,6 @@
         "AMR_GLASS_AMC_TEA_ATC": "A07AA09",
         "AMR_GLASS_AMC_TEA_ROUTE_ADMIN": "O",
         "AMR_GLASS_AMC_TEA_SALT": "XXXX",
-        "AMR_AMC_TEA_VOLUME": 1
+        "AMR_GLASS_AMC_TEA_VOLUME": 1
     }
 ]

--- a/src/domain/usecases/data-entry/amc/utils/__tests__/data/rawProductConsumption.json
+++ b/src/domain/usecases/data-entry/amc/utils/__tests__/data/rawProductConsumption.json
@@ -4,12 +4,12 @@
         "health_sector_manual": "PUB",
         "data_status_manual": 1,
         "health_level_manual": "C",
-        "packages": 50
+        "packages_manual": 50
     },
     {
         "AMR_GLASS_AMC_TEA_PRODUCT_ID": "P36",
         "data_status_manual": 3,
-        "packages": 96,
+        "packages_manual": 96,
         "health_sector_manual": "PUB",
         "health_level_manual": "C"
     },
@@ -18,26 +18,26 @@
         "data_status_manual": 3,
         "health_level_manual": "C",
         "health_sector_manual": "PUB",
-        "packages": 12
+        "packages_manual": 12
     },
     {
         "AMR_GLASS_AMC_TEA_PRODUCT_ID": "P36",
         "data_status_manual": 2,
         "health_level_manual": "C",
-        "packages": 73,
+        "packages_manual": 73,
         "health_sector_manual": "PUB"
     },
     {
         "AMR_GLASS_AMC_TEA_PRODUCT_ID": "P37",
         "data_status_manual": 1,
-        "packages": 45,
+        "packages_manual": 45,
         "health_level_manual": "C",
         "health_sector_manual": "PUB"
     },
     {
         "AMR_GLASS_AMC_TEA_PRODUCT_ID": "P37",
         "data_status_manual": 3,
-        "packages": 18,
+        "packages_manual": 18,
         "health_level_manual": "C",
         "health_sector_manual": "PUB"
     }

--- a/src/domain/usecases/data-entry/amc/utils/calculationConsumptionProductLevelData.ts
+++ b/src/domain/usecases/data-entry/amc/utils/calculationConsumptionProductLevelData.ts
@@ -131,7 +131,7 @@ function calculateContentPerProduct(product: ProductRegistryAttributes, unitsDat
         AMR_GLASS_AMC_TEA_STRENGTH,
         AMR_GLASS_AMC_TEA_STRENGTH_UNIT,
         AMR_GLASS_AMC_TEA_CONC_VOLUME: maybeConcVolume,
-        AMR_AMC_TEA_VOLUME: maybeVolume,
+        AMR_GLASS_AMC_TEA_VOLUME: maybeVolume,
         AMR_GLASS_AMC_TEA_PACKSIZE,
     } = product;
 
@@ -350,11 +350,11 @@ function calculateDDDPerProductConsumptionPackages(
         )}`
     );
     if (dddPerPackage) {
-        const { AMR_GLASS_AMC_TEA_PRODUCT_ID, packages, health_sector_manual, health_level_manual } =
+        const { AMR_GLASS_AMC_TEA_PRODUCT_ID, packages_manual, health_sector_manual, health_level_manual } =
             productConsumption;
 
         // 4b - ddd_cons_product = ddd_per_pack × packages (in year, health_sector and health_level)
-        const dddConsumptionPackages = dddPerPackage.value * packages;
+        const dddConsumptionPackages = dddPerPackage.value * packages_manual;
         logger.debug(`DDD per product consumption packages: ${dddConsumptionPackages}`);
         return {
             AMR_GLASS_AMC_TEA_PRODUCT_ID,
@@ -387,7 +387,7 @@ function getTonnesPerProduct(
     );
 
     const { AMR_GLASS_AMC_TEA_PRODUCT_ID: teiIdProduct, AMR_GLASS_AMC_TEA_ATC } = product;
-    const { packages, health_sector_manual, health_level_manual } = productConsumption;
+    const { packages_manual, health_sector_manual, health_level_manual } = productConsumption;
 
     const { standarizedStrengthUnit: contentUnit } = content;
     // 5a
@@ -398,13 +398,13 @@ function getTonnesPerProduct(
     logger.debug(`Conversion factor used to calculate content_tonnes: ${conversionFactor}`);
 
     // 5b - content_tonnes = (content × conv_factor × packages in the year, health_sector and health_level) ÷ 1e6
-    logger.debug(`Content tonnes: ${(content.value * conversionFactor * packages) / 1e6}`);
+    logger.debug(`Content tonnes: ${(content.value * conversionFactor * packages_manual) / 1e6}`);
     return {
         AMR_GLASS_AMC_TEA_PRODUCT_ID: teiIdProduct,
         year: period,
         health_sector_manual,
         health_level_manual,
-        contentTonnes: (content.value * conversionFactor * packages) / 1e6,
+        contentTonnes: (content.value * conversionFactor * packages_manual) / 1e6,
     };
 }
 
@@ -464,7 +464,7 @@ function aggregateDataByAtcRouteAdminYearHealthSectorAndHealthLevel(
                         AMR_GLASS_AMC_TEA_ATC,
                         AMR_GLASS_AMC_TEA_ROUTE_ADMIN,
                     } = product;
-                    const { packages, data_status_manual, health_sector_manual, health_level_manual } =
+                    const { packages_manual, data_status_manual, health_sector_manual, health_level_manual } =
                         productConsumption;
 
                     // 5c, 6a, 7a, 8a
@@ -514,7 +514,7 @@ function aggregateDataByAtcRouteAdminYearHealthSectorAndHealthLevel(
                                   ...accWithThisId,
                                   tons_autocalculated:
                                       accWithThisId.tons_autocalculated + contentTonnesOfProduct.contentTonnes,
-                                  packages_autocalculated: accWithThisId.packages_autocalculated + packages,
+                                  packages_autocalculated: accWithThisId.packages_autocalculated + packages_manual,
                                   ddds_autocalculated:
                                       accWithThisId.ddds_autocalculated +
                                       dddPerProductConsumptionPackages.dddConsumptionPackages,
@@ -525,7 +525,7 @@ function aggregateDataByAtcRouteAdminYearHealthSectorAndHealthLevel(
                                   route_admin_autocalculated: AMR_GLASS_AMC_TEA_ROUTE_ADMIN,
                                   salt_autocalculated: AMR_GLASS_AMC_TEA_SALT,
                                   year: period,
-                                  packages_autocalculated: packages,
+                                  packages_autocalculated: packages_manual,
                                   tons_autocalculated: contentTonnesOfProduct.contentTonnes,
                                   ddds_autocalculated: dddPerProductConsumptionPackages.dddConsumptionPackages,
                                   data_status_autocalculated: data_status_manual,

--- a/src/domain/usecases/data-entry/amc/utils/getConsumptionDataProductLevel.ts
+++ b/src/domain/usecases/data-entry/amc/utils/getConsumptionDataProductLevel.ts
@@ -53,6 +53,13 @@ export function getConsumptionDataProductLevel(params: {
         );
     }
 
+    if (!productDataTrackedEntities) {
+        logger.error(
+            `Cannot find Product Register Data for orgUnitsId ${orgUnitId} and period ${period} for calculations`
+        );
+        return Future.error("Cannot find Product Register Data");
+    }
+
     const rawProductConsumptionStage = productRegisterProgramMetadata?.programStages.find(
         ({ id }) => id === AMC_RAW_PRODUCT_CONSUMPTION_STAGE_ID
     );

--- a/src/domain/usecases/data-entry/amc/utils/getConsumptionDataSubstanceLevel.ts
+++ b/src/domain/usecases/data-entry/amc/utils/getConsumptionDataSubstanceLevel.ts
@@ -24,7 +24,9 @@ export function getConsumptionDataSubstanceLevel(params: {
         currentAtcVersionKey,
     } = params;
     if (!rawSubstanceConsumptionData) {
-        logger.error(`Cannot find Raw Substance Consumption Data for orgUnitsId ${orgUnitId} and period ${period}`);
+        logger.error(
+            `Cannot find Raw Substance Consumption Data for orgUnitsId ${orgUnitId} and period ${period} for calculations`
+        );
         return Future.error("Cannot find Raw Substance Consumption Data");
     }
 


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #8694gde4d [Changes to the AMC calculations](https://app.clickup.com/t/8694gde4d)

### :memo: Implementation

- [x] remove AMR_GLASS_AMC_TEA_CONC_VOLUME_UNIT and AMR_AMC_TEA_VOLUME_UNIT and not use it in code
- [x] change AMR_GLASS_AMC_DET_PACKAGES by AMR_GLASS_AMC_DET_PACKAGES_MANUAL
- [x] use AMR_GLASS_AMC_TEA_VOLUME instead of AMR_AMC_TEA_VOLUME
- [x] In the calculation script, skip the calculation if the ATC code is Z99ZZ99 as this mean the product does not have a ATC then no DDD; Skip the calculation if the combination code is Z99ZZ99_99. In both case, do not fill in the program stage AMC - Raw Product Consumption in program AMC - Product Register


**METADATA CHANGES in dev-238 (NOT IN APDV):**
- change data element [AMR_GLASS_AMC_DET_PACKAGES](https://dev.eyeseetea.com/who-dev-238/dhis-web-maintenance/index.html#/edit/dataElementSection/dataElement/yQ23GizXyTe) by [AMR_GLASS_AMC_DET_PACKAGES_MANUAL](https://dev.eyeseetea.com/who-dev-238/dhis-web-maintenance/index.html#/edit/dataElementSection/dataElement/yimWSvsiGhi) in [program stages AMC - Raw Product Consumption in programs AMC - Product Register](https://dev.eyeseetea.com/who-dev-238/dhis-web-maintenance/index.html#/edit/programSection/program/G6ChA5zMW9n)
- Name changed to [this DE](https://dev.eyeseetea.com/who-dev-238/dhis-web-maintenance/index.html#/edit/programSection/trackedEntityAttribute/z2KUjstBwLA) from AMR_AMC_TEA_VOLUME to AMR_GLASS_AMC_TEA_VOLUME. 
- **It's needed to remove from [attributes in programs AMC - Product Register](https://dev.eyeseetea.com/who-dev-238/dhis-web-maintenance/index.html#/edit/programSection/program/G6ChA5zMW9n)   AMR_GLASS_AMC_TEA_CONC_VOLUME_UNIT and AMR_AMC_TEA_VOLUME_UNIT because I cannot do it, but these are no longer used in the code**

[Modified in data store glass](https://dev.eyeseetea.com/who-dev-238/dhis-web-datastore/index.html#/edit/glass/modules) ➝ [modules](https://dev.eyeseetea.com/who-dev-238/dhis-web-datastore/index.html#/edit/glass/modules) ➝ AMC: 
- in dataColumns: instead of "Packagesmanual", "Datastatusmanual", "HealthSectormanual" and  "HealthLevelmanual" should be packages_manual, data_status_manual, health_sector_manual and health_level_manual according with the codes of this data elements.
**- in teiColumns, when removing from [attributes in programs AMC - Product Register](https://dev.eyeseetea.com/who-dev-238/dhis-web-maintenance/index.html#/edit/programSection/program/G6ChA5zMW9n)   AMR_GLASS_AMC_TEA_CONC_VOLUME_UNIT and AMR_AMC_TEA_VOLUME_UNIT, it's needed also to remove Concentrationvolumeunit and Volumeunit. I have added "Volume" that was missing.**



### :video_camera: Screenshots/Screen capture
**Product with correct code:**
![Screenshot from 2024-05-21 08-58-23](https://github.com/EyeSeeTea/glass-dev/assets/49402898/3dfba46a-b506-4050-83d0-51b49f627a29)
![Screenshot from 2024-05-21 08-58-38](https://github.com/EyeSeeTea/glass-dev/assets/49402898/687d3996-d9bf-4b9e-9bda-83879523be2f)

**Products with Z99ZZ99 or Z99ZZ99_99 codes:**
![Screenshot from 2024-05-21 09-04-06](https://github.com/EyeSeeTea/glass-dev/assets/49402898/cc9c8961-a416-4d2f-9ecf-099b6b88a305)
![Screenshot from 2024-05-21 09-03-50](https://github.com/EyeSeeTea/glass-dev/assets/49402898/5fff1247-284b-4cbe-80ad-74ed7b39ea35)

**Raw substances:**
![Screenshot from 2024-05-21 08-59-25](https://github.com/EyeSeeTea/glass-dev/assets/49402898/afd0a10d-5a51-4fe3-97f5-353348f595a7)
![Screenshot from 2024-05-21 08-59-19](https://github.com/EyeSeeTea/glass-dev/assets/49402898/49ffd6ec-444d-4610-9701-c947f5a4d2a9)

**Calculated substances:**
![Screenshot from 2024-05-21 08-59-11](https://github.com/EyeSeeTea/glass-dev/assets/49402898/09b905e4-c826-4cb0-a72f-0e6cf0d13b21)

(Just that one for 2021 period, the one with code Z99ZZ99 is not calculated)
![Screenshot from 2024-05-21 09-02-59](https://github.com/EyeSeeTea/glass-dev/assets/49402898/0eab467f-3e26-4df8-95a7-ec9693756592)



### :fire: Testing
[AMC-Substance.Level.Data-THA-TEMPLATE (1).xlsx](https://github.com/EyeSeeTea/glass-dev/files/15385814/AMC-Substance.Level.Data-THA-TEMPLATE.1.xlsx)
[AMC-Product.Level.Data-THA-TEMPLATE (2).xlsx](https://github.com/EyeSeeTea/glass-dev/files/15385815/AMC-Product.Level.Data-THA-TEMPLATE.2.xlsx)

