### PR TITLE
Bug: packages autocalculated

### DIFF
--- a/src/data/repositories/data-entry/AMCProductDataDefaultRepository.ts
+++ b/src/data/repositories/data-entry/AMCProductDataDefaultRepository.ts
@@ -101,10 +101,11 @@ export class AMCProductDataDefaultRepository implements AMCProductDataRepository
 
     getProductRegisterAndRawProductConsumptionByProductIds(
         orgUnitId: Id,
-        productIds: string[]
+        productIds: string[],
+        period: string
     ): FutureData<ProductDataTrackedEntity[]> {
         return Future.fromPromise(
-            this.getProductRegisterAndRawProductConsumptionByProductIdsAsync(orgUnitId, productIds)
+            this.getProductRegisterAndRawProductConsumptionByProductIdsAsync(orgUnitId, productIds, period)
         ).map(trackedEntities => {
             return this.mapFromTrackedEntitiesToProductData(trackedEntities);
         });
@@ -134,7 +135,8 @@ export class AMCProductDataDefaultRepository implements AMCProductDataRepository
 
     private async getProductRegisterAndRawProductConsumptionByProductIdsAsync(
         orgUnit: Id,
-        productIds: string[]
+        productIds: string[],
+        period: string
     ): Promise<D2TrackerTrackedEntity[]> {
         const trackedEntities: D2TrackerTrackedEntity[] = [];
         const pageSize = 250;
@@ -143,9 +145,18 @@ export class AMCProductDataDefaultRepository implements AMCProductDataRepository
         let result;
         const productIdsString = productIds.join(";");
         const filter = `${AMR_GLASS_AMC_TEA_PRODUCT_ID}:IN:${productIdsString}`;
+        const enrollmentEnrolledAfter = `${period}-1-1`;
+        const enrollmentEnrolledBefore = `${period}-12-31`;
 
         do {
-            result = await this.getTrackedEntitiesOfPage({ orgUnit, filter, page, pageSize });
+            result = await this.getTrackedEntitiesOfPage({
+                orgUnit,
+                filter,
+                page,
+                pageSize,
+                enrollmentEnrolledBefore,
+                enrollmentEnrolledAfter,
+            });
             trackedEntities.push(...result.instances);
             page++;
         } while (result.page < totalPages);

--- a/src/data/repositories/data-entry/AMCProductDataDefaultRepository.ts
+++ b/src/data/repositories/data-entry/AMCProductDataDefaultRepository.ts
@@ -278,7 +278,8 @@ export class AMCProductDataDefaultRepository implements AMCProductDataRepository
                         trackedEntityId: trackedEntity.trackedEntity,
                         enrollmentId: trackedEntity.enrollments[0].enrollment,
                         enrollmentStatus: trackedEntity.enrollments[0].status,
-                        events,
+                        enrolledAt: trackedEntity.enrollments[0].enrolledAt,
+                        events: events,
                         attributes: trackedEntity.attributes.map(({ attribute, valueType, value }) => ({
                             id: attribute,
                             valueType: valueType as string,
@@ -300,9 +301,14 @@ export class AMCProductDataDefaultRepository implements AMCProductDataRepository
         return rawSubstanceConsumptionCalculatedData
             .map(data => {
                 const productId = data.AMR_GLASS_AMC_TEA_PRODUCT_ID;
-                const productDataTrackedEntity = productDataTrackedEntities.find(productDataTrackedEntity =>
-                    productDataTrackedEntity.attributes.some(attribute => attribute.value === productId)
-                );
+                const productDataTrackedEntity = productDataTrackedEntities.find(productDataTrackedEntity => {
+                    const enrolledYear = new Date(productDataTrackedEntity.enrolledAt).getFullYear();
+                    return (
+                        productDataTrackedEntity.attributes.some(attribute => attribute.value === productId) &&
+                        enrolledYear === Number(period)
+                    );
+                });
+
                 if (productDataTrackedEntity) {
                     const dataValues: DataValue[] = rawSubstanceConsumptionCalculatedStageMetadata.dataElements.map(
                         ({ id, code, valueType, optionSetValue, optionSet }) => {

--- a/src/domain/entities/data-entry/amc/ProductDataTrackedEntity.ts
+++ b/src/domain/entities/data-entry/amc/ProductDataTrackedEntity.ts
@@ -7,7 +7,7 @@ export type EventDataValue = {
 
 export type Event = {
     eventId: Id;
-    occurredAt: Id;
+    occurredAt: string;
     dataValues: EventDataValue[];
 };
 
@@ -22,6 +22,7 @@ export type ProductDataTrackedEntity = {
     trackedEntityId: Id;
     enrollmentId: Id;
     enrollmentStatus: Id;
+    enrolledAt: string;
     events: Event[];
     attributes: Attributes[];
 };

--- a/src/domain/repositories/data-entry/AMCProductDataRepository.ts
+++ b/src/domain/repositories/data-entry/AMCProductDataRepository.ts
@@ -23,7 +23,8 @@ export interface AMCProductDataRepository {
     getProductRegisterProgramMetadata(): FutureData<ProductRegisterProgramMetadata | undefined>;
     getProductRegisterAndRawProductConsumptionByProductIds(
         orgUnitId: Id,
-        productIds: string[]
+        productIds: string[],
+        period: string
     ): FutureData<ProductDataTrackedEntity[]>;
     getAllProductRegisterAndRawProductConsumptionByPeriod(
         orgUnitId: Id,

--- a/src/domain/usecases/data-entry/amc/CalculateConsumptionDataProductLevelUseCase.ts
+++ b/src/domain/usecases/data-entry/amc/CalculateConsumptionDataProductLevelUseCase.ts
@@ -49,7 +49,8 @@ export class CalculateConsumptionDataProductLevelUseCase {
                     productDataTrackedEntities:
                         this.amcProductDataRepository.getProductRegisterAndRawProductConsumptionByProductIds(
                             orgUnitId,
-                            productIds
+                            productIds,
+                            period
                         ),
                     atcVersionHistory: this.atcRepository.getAtcHistory(),
                 });


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #8694p3z6j [Bug: packages autocalculated](https://app.clickup.com/t/8694p3z6j)

### :memo: Implementation
- Filter products by period to use in calculations

METADATA CHANGES:
Following changes in https://app.clickup.com/t/8694ap3qu, also I would like to propose that inside the zip in atc_ddd_index.json all units that are millions international unit, the code should be MIU like in the [option set of measure units](https://dev.eyeseetea.com/who-dev-238/dhis-web-maintenance/index.html#/edit/otherSection/optionSet/iSiwVc3bAgi/options) (zip attached with new data required). And also according to salt and units inside atc_ddd_index.json, in the [option set of salt ](https://dev.eyeseetea.com/who-dev-238/dhis-web-maintenance/index.html#/edit/otherSection/optionSet/qOCslKTMCBM/options)the following options are missing: SULF(Sulfate
) and METS (Methane sulfonate
) . Also in [measure units optioon set](https://dev.eyeseetea.com/who-dev-238/dhis-web-maintenance/index.html#/edit/otherSection/optionSet/iSiwVc3bAgi/options) the following option was missing: UD (unit dose) but I have added to dev-238.

[atc_classification_version.zip](https://github.com/EyeSeeTea/glass-dev/files/15469243/atc_classification_version.zip)


### :video_camera: Screenshots/Screen capture
2021:
[AMC-PRODUCT-SUBMITTED-DZA-Populated (18).xlsx](https://github.com/EyeSeeTea/glass-dev/files/15465045/AMC-PRODUCT-SUBMITTED-DZA-Populated.18.xlsx)
[AMC-PRODUCT-CALCULATED-DZA-Populated (13).xlsx](https://github.com/EyeSeeTea/glass-dev/files/15465046/AMC-PRODUCT-CALCULATED-DZA-Populated.13.xlsx)

2020:
[AMC-PRODUCT-SUBMITTED-DZA-Populated (17).xlsx](https://github.com/EyeSeeTea/glass-dev/files/15465059/AMC-PRODUCT-SUBMITTED-DZA-Populated.17.xlsx)
[AMC-PRODUCT-CALCULATED-DZA-Populated (12).xlsx](https://github.com/EyeSeeTea/glass-dev/files/15465061/AMC-PRODUCT-CALCULATED-DZA-Populated.12.xlsx)


### :fire: Testing
[AMC-Product Level Data-DZA-TEMPLATE_2021.xlsx](https://github.com/EyeSeeTea/glass-dev/files/15465047/AMC-Product.Level.Data-DZA-TEMPLATE_2021.xlsx)
[AMC-Product Level Data-DZA-TEMPLATE_2020.xlsx](https://github.com/EyeSeeTea/glass-dev/files/15465064/AMC-Product.Level.Data-DZA-TEMPLATE_2020.xlsx)
