### PR TITLE
Bug: Got errors on A07AA and P01AB but no product with these codes in the file

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-04-12T05:19:17.327Z\n"
-"PO-Revision-Date: 2024-04-12T05:19:17.327Z\n"
+"POT-Creation-Date: 2024-06-06T12:57:53.842Z\n"
+"PO-Revision-Date: 2024-06-06T12:57:53.842Z\n"
 
 msgid "Template {{id}} not loaded"
 msgstr ""
@@ -98,11 +98,6 @@ msgid "Longitude"
 msgstr ""
 
 msgid "Invalid choice was chosen"
-msgstr ""
-
-msgid ""
-"If ATC code in ATC levels 4 A07AA and P01AB, Route of administration must "
-"be oral"
 msgstr ""
 
 msgid "The AST results provided are not valid (they are all empty)"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2024-04-12T05:19:17.327Z\n"
+"POT-Creation-Date: 2024-06-06T12:57:53.842Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -98,11 +98,6 @@ msgid "Longitude"
 msgstr ""
 
 msgid "Invalid choice was chosen"
-msgstr ""
-
-msgid ""
-"If ATC code in ATC levels 4 A07AA and P01AB, Route of administration must be "
-"oral"
 msgstr ""
 
 msgid "The AST results provided are not valid (they are all empty)"

--- a/src/domain/usecases/data-entry/amc/CustomValidationsAMCProductData.ts
+++ b/src/domain/usecases/data-entry/amc/CustomValidationsAMCProductData.ts
@@ -13,9 +13,9 @@ const AMR_GLASS_AMC_TEA_ROUTE_ADMIN = "m4eyu3tO5IV";
 const AMR_GLASS_AMC_TEA_SALT = "K8wjLXjYFzf";
 const AMR_GLASS_AMC_TEA_PRODUCT_ID = "iasfoeU8veF";
 const atcLevel4WithOralROA1 = "A07AA";
-const atcLevel4WithOralROA2 = "P01AB";
-const atcLevel4WithOralROA3 = "J01XD";
-const atcLevel4WithOralROA4 = "J01XA";
+const atcLevel4WithOralOrRectalROA2 = "P01AB";
+const atcLevel4WithParenteralROA3 = "J01XD";
+const atcLevel4WithParenteralROA4 = "J01XA";
 const atcCodeWithSaltHippAndMand = "J01XX05";
 const atcCodeWithRoaOAndSaltDefault = "J01FA01";
 const CODE_PRODUCT_NOT_HAVE_ATC = "Z99ZZ99";
@@ -161,17 +161,34 @@ export class CustomValidationsAMCProductData {
                     } else {
                         const atcCodeByLevel = getAtcCodeByLevel(atcData, atcCode);
                         const atcCodeLevel4 = atcCodeByLevel?.level4;
+
+                        if (atcCodeLevel4 === atcLevel4WithOralROA1 && roa && roa !== "O") {
+                            curErrors.push({
+                                error: i18n.t(
+                                    `If ATC code is in ATC level ${atcCodeLevel4}, Route of administration must be oral`
+                                ),
+                                line: tei.trackedEntity ? parseInt(tei.trackedEntity) + 6 : -1,
+                            });
+                        }
+
+                        if (atcCodeLevel4 === atcLevel4WithOralOrRectalROA2 && roa && roa !== "O" && roa !== "R") {
+                            curErrors.push({
+                                error: i18n.t(
+                                    `If ATC code is in ATC level ${atcCodeLevel4}, Route of administration must be oral or rectal`
+                                ),
+                                line: tei.trackedEntity ? parseInt(tei.trackedEntity) + 6 : -1,
+                            });
+                        }
+
                         if (
-                            (atcCodeLevel4 === atcLevel4WithOralROA1 ||
-                                atcCodeLevel4 === atcLevel4WithOralROA2 ||
-                                atcCodeLevel4 === atcLevel4WithOralROA3 ||
-                                atcCodeLevel4 === atcLevel4WithOralROA4) &&
+                            (atcCodeLevel4 === atcLevel4WithParenteralROA3 ||
+                                atcCodeLevel4 === atcLevel4WithParenteralROA4) &&
                             roa &&
-                            roa !== "O"
+                            roa !== "P"
                         ) {
                             curErrors.push({
                                 error: i18n.t(
-                                    `If ATC code in ATC levels 4 A07AA and P01AB, Route of administration must be oral`
+                                    `If ATC code is in ATC level ${atcCodeLevel4}, Route of administration must be parenteral`
                                 ),
                                 line: tei.trackedEntity ? parseInt(tei.trackedEntity) + 6 : -1,
                             });

--- a/src/domain/usecases/data-entry/amc/CustomValidationsAMCProductData.ts
+++ b/src/domain/usecases/data-entry/amc/CustomValidationsAMCProductData.ts
@@ -165,7 +165,7 @@ export class CustomValidationsAMCProductData {
                         if (atcCodeLevel4 === atcLevel4WithOralROA1 && roa && roa !== "O") {
                             curErrors.push({
                                 error: i18n.t(
-                                    `If ATC code is in ATC level ${atcCodeLevel4}, Route of administration must be oral`
+                                    `If ATC code ${atcCode} is in ATC level ${atcCodeLevel4}, Route of administration must be oral`
                                 ),
                                 line: tei.trackedEntity ? parseInt(tei.trackedEntity) + 6 : -1,
                             });
@@ -174,7 +174,7 @@ export class CustomValidationsAMCProductData {
                         if (atcCodeLevel4 === atcLevel4WithOralOrRectalROA2 && roa && roa !== "O" && roa !== "R") {
                             curErrors.push({
                                 error: i18n.t(
-                                    `If ATC code is in ATC level ${atcCodeLevel4}, Route of administration must be oral or rectal`
+                                    `If ATC code ${atcCode} is in ATC level ${atcCodeLevel4}, Route of administration must be oral or rectal`
                                 ),
                                 line: tei.trackedEntity ? parseInt(tei.trackedEntity) + 6 : -1,
                             });
@@ -188,7 +188,7 @@ export class CustomValidationsAMCProductData {
                         ) {
                             curErrors.push({
                                 error: i18n.t(
-                                    `If ATC code is in ATC level ${atcCodeLevel4}, Route of administration must be parenteral`
+                                    `If ATC code ${atcCode} is in ATC level ${atcCodeLevel4}, Route of administration must be parenteral`
                                 ),
                                 line: tei.trackedEntity ? parseInt(tei.trackedEntity) + 6 : -1,
                             });
@@ -197,7 +197,7 @@ export class CustomValidationsAMCProductData {
                         if (validATCCode === atcCodeWithSaltHippAndMand && salt && salt !== "HIPP" && salt !== "MAND") {
                             curErrors.push({
                                 error: i18n.t(
-                                    `If ATC code is ${atcCodeWithSaltHippAndMand}, salt must be either HIPP or MAND`
+                                    `If ATC code ${atcCode} is ${atcCodeWithSaltHippAndMand}, salt must be either HIPP or MAND`
                                 ),
                                 line: tei.trackedEntity ? parseInt(tei.trackedEntity) + 6 : -1,
                             });


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #8694rjm8n [Bug: Got errors on A07AA and P01AB but no product with these codes in the file](https://app.clickup.com/t/8694rjm8n)

### :memo: Implementation
- Fix validation of ATC codes level 4 and improve error messages

### :video_camera: Screenshots/Screen capture
![image](https://github.com/EyeSeeTea/glass-dev/assets/49402898/9d19c2b7-d0eb-4e64-ba5a-328a4c3e667d)

### :fire: Testing

[AMC-Product Level Data-THA-TEMPLATE (2).xlsx](https://github.com/user-attachments/files/15626955/AMC-Product.Level.Data-THA-TEMPLATE.2.xlsx)

[AMC - WIDP_Product Register_20240531_TEST_FRA_2022_WITHOUT_A07_P01AB.xlsx](https://github.com/user-attachments/files/15628383/AMC.-.WIDP_Product.Register_20240531_TEST_FRA_2022_WITHOUT_A07_P01AB.xlsx)


