### PR TITLE
AMR AGG Implementation Questionnaire new validation rules

### DIFF
--- a/src/webapp/components/questionnaire/widgets/NumberWidget.tsx
+++ b/src/webapp/components/questionnaire/widgets/NumberWidget.tsx
@@ -46,7 +46,7 @@ const NumberWidget: React.FC<NumberWidgetProps> = props => {
                 onChange={updateState}
                 value={stateValue || ""}
                 disabled={props.disabled}
-                error={validationError !== undefined}
+                error={validationError !== undefined && validationError.length > 0}
             />
             <ValidationErrorText>{validationError}</ValidationErrorText>
         </>


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #8694rjkcm ,   https://app.clickup.com/t/8694rjkcm

### :memo: Implementation
1. Configure error message in datastore, for rules with  value of one data element should be less than value of another data element.
2. Implement rule for data element value less than const
3. Implement rule for data element value double of another
4. Fix : reset question values if section is hidden

### NOTE : DATASTORE CHANGES REQUIRED ####
the following should be the rules value in datastore Glass --> Modules -->  
{"name": "AMR", 
questionnaires : [
  "id": "OYc0CihXiSn", 
    rules : <value below> 
]
} 
 ```
"rules": [
          {
            "dataElementCode": "AMR_AMR_ACUTE_CARE_NUMBER",
            "constValue": "100",
            "type": "questionValueLessThanConst",
            "errorMessage": "Number of acute-care facilities should be more than 100"
          },
           {
            "dataElementCode": "AMR_AMR_HOSPITALS_NUMBER",
            "doubleDataElementCode": "AMR_AMR_ACUTE_CARE_NUMBER",
            "type": "questionValueDoubleOfAnother",
            "errorMessage": "Number of acute-care facilities should be atleast double the number of hospitals"
          },
          {
            "dataElementCode": "AMR_GLASS_DATA",
            "sectionCodes": [
              "AMR_OVERVIEW_Q7",
              "AMR_OVERVIEW_Q8"
            ],
            "type": "setSectionsVisibility"
          },
          {
            "dataElementCodesLowerToHigher": {
              "AMR_GLASS_ACUTE_CARE_NUMBER": "AMR_AMR_ACUTE_CARE_NUMBER",
              "AMR_GLASS_HOSPITALS_NUMBER": "AMR_AMR_HOSPITALS_NUMBER",
              "AMR_GLASS_INPATIENT_ADM_NUMBER": "AMR_AMR_INPATIENT_ADM_NUMBER",
              "AMR_GLASS_INPATIENT_DAY_NUMBER": "AMR_AMR_INPATIENT_DAY_NUMBER",
              "AMR_GLASS_OUTPATIENT_CONS_NUMBER": "AMR_AMR_OUTPATIENT_CONS_NUMBER"
            },
            "errorMessage": "This value cannot be higher than the value provided in question 5",
            "type": "sectionValuesHigherThan"
          },
          {
            "dataElementCodesLowerToHigher": {
              "AMR_AMR_HOSPITALS_NUMBER": "AMR_AMR_ACUTE_CARE_NUMBER"
            },
            "errorMessage": "Number of hospitals cannot not to equal or exceed the number of overall HCFs",
            "type": "sectionValuesHigherThan"
          },
          {
            "dataElementCodesLowerToHigher": {
              "AMR_AMR_INPATIENT_ADM_NUMBER": "AMR_AMR_INPATIENT_DAY_NUMBER"
            },
            "errorMessage": "Number of inpatient days cannot be less than the number of inpatient admissions in the overall HCFs",
            "type": "sectionValuesHigherThan"
          },
          {
            "dataElementCodesLowerToHigher": {
              "AMR_AMR_HOSPITALS_NUMBER": "AMR_AMR_INPATIENT_ADM_NUMBER"
            },
            "errorMessage": "Number of inpatient admissions of the overall hospitals couldn't be equal to or less than the number of overall hospitals",
            "type": "sectionValuesHigherThan"
          },
          {
            "dataElementCodesLowerToHigher": {
              "AMR_GLASS_HOSPITALS_NUMBER": "AMR_GLASS_ACUTE_CARE_NUMBER"
            },
            "errorMessage": "Number of hospitals reporting to GLASS cannot not to equal or exceed the number of overall HCFs reporting to GLASS",
            "type": "sectionValuesHigherThan"
          },
          {
            "dataElementCodesLowerToHigher": {
              "AMR_GLASS_INPATIENT_ADM_NUMBER": "AMR_GLASS_INPATIENT_DAY_NUMBER"
            },
            "errorMessage": "Number of inpatient days cannot be less than the number of inpatient admissions in the overall HCFs",
            "type": "sectionValuesHigherThan"
          },
          {
            "dataElementCodesLowerToHigher": {
              "AMR_GLASS_HOSPITALS_NUMBER": "AMR_GLASS_INPATIENT_ADM_NUMBER"
            },
            "errorMessage": "Number of inpatient admissions of the overall hospitals couldn't be equal to or less than the number of overall hospitals",
            "type": "sectionValuesHigherThan"
          },
          {
            "dataElementCodesLowerToHigher": {
              "LOCAL_LAB_EQA_NUMBER_DATA_CALL": "LAB_NUMBER_DATA_CALL"
            },
            "errorMessage": "Number of labs participating in surveillance cannot be less than number of labs participating in EQA",
            "type": "sectionValuesHigherThan"
          }
        ]
```


### :video_camera: Screenshots/Screen capture
<img width="1728" alt="Screenshot 2024-06-19 at 12 14 36 AM" src="https://github.com/EyeSeeTea/glass-dev/assets/83749675/54aa3ed7-b510-40c2-bc9e-330c375595c9">


### :fire: Testing
