### PR TITLE
fix: duplicate row detection for AMR AGG Ris and Sample files

### DIFF
--- a/src/data/repositories/data-entry/DataValuesDefaultRepository.ts
+++ b/src/data/repositories/data-entry/DataValuesDefaultRepository.ts
@@ -30,7 +30,7 @@ export class DataValuesDefaultRepository implements DataValuesRepository {
         ).flatMap(response => {
             return apiToFuture(this.api.system.waitFor(response.response.jobType, response.response.id)).map(result => {
                 if (result) {
-                    return {
+                    const importStatus: DataValuesSaveSummary = {
                         status: result.status,
                         description: result.description,
                         importCount: {
@@ -39,11 +39,12 @@ export class DataValuesDefaultRepository implements DataValuesRepository {
                             ignored: result.importCount.ignored,
                             deleted: result.importCount.deleted,
                         },
-                        conficts: result.conflicts,
+                        conflicts: result.conflicts,
                         importTime: new Date(response.response.created),
                     };
+                    return importStatus;
                 } else {
-                    return {
+                    const errorStatus: DataValuesSaveSummary = {
                         status: "ERROR",
                         description: "An unexpected error has ocurred saving data values",
                         importCount: {
@@ -52,9 +53,11 @@ export class DataValuesDefaultRepository implements DataValuesRepository {
                             ignored: 0,
                             deleted: 0,
                         },
-                        conficts: [],
+                        conflicts: [],
                         importTime: new Date(response.response.created),
                     };
+
+                    return errorStatus;
                 }
             });
         });

--- a/src/domain/usecases/data-entry/amr/ImportRISFile.ts
+++ b/src/domain/usecases/data-entry/amr/ImportRISFile.ts
@@ -21,6 +21,7 @@ import {
 import { includeBlockingErrors } from "../utils/includeBlockingErrors";
 import { mapDataValuesToImportSummary } from "../utils/mapDhis2Summary";
 import { RISData } from "../../../entities/data-entry/amr-external/RISData";
+import { checkDuplicateRowsRIS } from "../utils/checkDuplicateRows";
 
 const AMR_AMR_DS_INPUT_FILES_RIS_DS_ID = "CeQPmXgrhHF";
 const AMR_DATA_PATHOGEN_ANTIBIOTIC_BATCHID_CC_ID = "S427AvQESbw";
@@ -74,6 +75,7 @@ export class ImportRISFile {
                 const yearErrors = checkYear(risDataItems, year);
                 const countryErrors = checkCountry(risDataItems, countryCode);
                 const blockingCategoryOptionErrors: { error: string; line: number }[] = [];
+                const duplicateRowErrors = checkDuplicateRowsRIS(risDataItems);
 
                 const dataValues = risDataItems
                     .map((risData, index) => {
@@ -126,6 +128,7 @@ export class ImportRISFile {
                     ...batchIdErrors,
                     ...yearErrors,
                     ...countryErrors,
+                    ...duplicateRowErrors,
                 ];
 
                 if (allBlockingErrors.length > 0) {

--- a/src/domain/usecases/data-entry/amr/ImportSampleFile.ts
+++ b/src/domain/usecases/data-entry/amr/ImportSampleFile.ts
@@ -17,6 +17,7 @@ import { includeBlockingErrors } from "../utils/includeBlockingErrors";
 import { mapDataValuesToImportSummary } from "../utils/mapDhis2Summary";
 import { SampleDataRepository } from "../../../repositories/data-entry/SampleDataRepository";
 import { SampleData } from "../../../entities/data-entry/amr-external/SampleData";
+import { checkDuplicateRowsSAMPLE } from "../utils/checkDuplicateRows";
 
 const AMR_AMR_DS_Input_files_Sample_DS_ID = "OcAB7oaC072";
 const AMR_BATCHID_CC_ID = "rEMx3WFeLcU";
@@ -56,6 +57,7 @@ export class ImportSampleFile {
                 const batchIdErrors = checkBatchId(risDataItems, batchId);
                 const yearErrors = checkYear(risDataItems, year);
                 const countryErrors = checkCountry(risDataItems, countryCode);
+                const duplicateRowErrors = checkDuplicateRowsSAMPLE(risDataItems);
 
                 const dataValues = risDataItems
                     .map(risData => {
@@ -119,6 +121,7 @@ export class ImportSampleFile {
                                         ...yearErrors,
                                         ...countryErrors,
                                         ...dhis2ValidationErrors,
+                                        ...duplicateRowErrors,
                                     ]);
 
                                     return summaryWithConsistencyBlokingErrors;

--- a/src/domain/usecases/data-entry/utils/checkDuplicateRows.ts
+++ b/src/domain/usecases/data-entry/utils/checkDuplicateRows.ts
@@ -1,0 +1,48 @@
+import i18n from "../../../../locales";
+import { RISData } from "../../../entities/data-entry/amr-external/RISData";
+import { SampleData } from "../../../entities/data-entry/amr-external/SampleData";
+import { ConsistencyError } from "../../../entities/data-entry/ImportSummary";
+
+export function checkDuplicateRowsRIS(fileData: RISData[]): ConsistencyError[] {
+    const concantRowIdentifiers = fileData.map((item, index) => {
+        return {
+            line: index + 1,
+            rowIdentifier: `${item.SPECIMEN}, ${item.PATHOGEN}, ${item.GENDER}, ${item.ORIGIN}, ${item.AGEGROUP}, ${item.ANTIBIOTIC}, ${item.BATCHIDDS}`,
+        };
+    });
+
+    const duplicateRows = _(concantRowIdentifiers)
+        .groupBy("rowIdentifier")
+        .filter(group => group.length > 1)
+        .value();
+
+    const errors = duplicateRows.map(duplicateRow => ({
+        error: i18n.t(`Duplicate rows found for combination : ${duplicateRow[0]?.rowIdentifier}`),
+        count: duplicateRow.length,
+        lines: duplicateRow.map(row => row.line),
+    }));
+
+    return errors;
+}
+
+export function checkDuplicateRowsSAMPLE(fileData: SampleData[]): ConsistencyError[] {
+    const concantRowIdentifiers = fileData.map((item, index) => {
+        return {
+            line: index + 1,
+            rowIdentifier: `${item.SPECIMEN}, ${item.GENDER}, ${item.ORIGIN}, ${item.AGEGROUP}, ${item.BATCHIDDS}`,
+        };
+    });
+
+    const duplicateRows = _(concantRowIdentifiers)
+        .groupBy("rowIdentifier")
+        .filter(group => group.length > 1)
+        .value();
+
+    const errors = duplicateRows.map(duplicateRow => ({
+        error: i18n.t(`Duplicate rows found for combination : ${duplicateRow[0]?.rowIdentifier}`),
+        count: duplicateRow.length,
+        lines: duplicateRow.map(row => row.line),
+    }));
+
+    return errors;
+}

--- a/src/domain/usecases/data-entry/utils/includeBlockingErrors.ts
+++ b/src/domain/usecases/data-entry/utils/includeBlockingErrors.ts
@@ -1,7 +1,7 @@
 import { ConsistencyError, ImportSummary } from "../../../entities/data-entry/ImportSummary";
 
 export function includeBlockingErrors(importSummary: ImportSummary, blockingErrors: ConsistencyError[]): ImportSummary {
-    const status = blockingErrors ? "ERROR" : importSummary.status;
+    const status = blockingErrors && blockingErrors.length > 0 ? "ERROR" : importSummary.status;
 
     return {
         ...importSummary,

--- a/src/domain/usecases/data-entry/utils/mapDhis2Summary.ts
+++ b/src/domain/usecases/data-entry/utils/mapDhis2Summary.ts
@@ -1,3 +1,4 @@
+import i18n from "@eyeseetea/d2-ui-components/locales";
 import { DataValuesSaveSummary } from "../../../entities/data-entry/DataValuesSaveSummary";
 import { ImportSummary } from "../../../entities/data-entry/ImportSummary";
 
@@ -22,15 +23,24 @@ export function mapDataValuesToImportSummary(dhis2Summary: DataValuesSaveSummary
               }) || []
             : [];
 
-    const finalBlockingErrors = _.compact([
-        ...blokingErrors,
+    const ignoredErrors =
         dhis2Summary.importCount.ignored > 0
-            ? {
-                  error: "Import Ignored",
-                  count: dhis2Summary.importCount.ignored,
-              }
-            : undefined,
-    ]);
+            ? dhis2Summary.conflicts && dhis2Summary.conflicts.length > 0
+                ? dhis2Summary.conflicts?.map(status => {
+                      return {
+                          error: status.value,
+                          count: 1,
+                      };
+                  })
+                : [
+                      {
+                          error: i18n.t("Import Ignored"),
+                          count: dhis2Summary.importCount.ignored,
+                      },
+                  ]
+            : [];
+
+    const finalBlockingErrors = _.compact([...blokingErrors, ...ignoredErrors]);
 
     const status = finalBlockingErrors.length > 0 ? "ERROR" : nonBlockingErrors.length > 0 ? "WARNING" : "SUCCESS";
 


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #8694m1xdn,    https://app.clickup.com/t/8694m1xdn

### :memo: Implementation
1. Add a pre import check to detect duplicates in rows of SAMPLE and RIS files for AMR AGG files.

### :video_camera: Screenshots/Screen capture

https://github.com/EyeSeeTea/glass-dev/assets/83749675/d9799801-9171-4662-b3dc-dae0ecf5c3a6



### :fire: Testing
Files with duplicates which will give duplicate detected blocking error for POLAND 2022 DS1 : 
[GLASS_Salmonella_2022_corrected_DS1-RIS.xlsx](https://github.com/user-attachments/files/15896375/GLASS_Salmonella_2022_corrected_DS1-RIS.xlsx)
[POL_2022_SAMPLE.txt](https://github.com/user-attachments/files/15896374/POL_2022_SAMPLE.txt)
