### PR TITLE
fix: On delete, do not run consistency checks and ignore 'import ignored' error

### DIFF
--- a/src/domain/usecases/data-entry/amr/ImportRISFile.ts
+++ b/src/domain/usecases/data-entry/amr/ImportRISFile.ts
@@ -120,16 +120,19 @@ export class ImportRISFile {
                     .uniqBy("error")
                     .value();
 
-                const allBlockingErrors = [
-                    ...blockingCategoryOptionConsistencyErrors,
-                    ...pathogenAntibioticErrors,
-                    ...specimenPathogenErrors,
-                    ...astResultsErrors,
-                    ...batchIdErrors,
-                    ...yearErrors,
-                    ...countryErrors,
-                    ...duplicateRowErrors,
-                ];
+                const allBlockingErrors =
+                    action === "DELETE" //If delete, ignore consistency checks
+                        ? []
+                        : [
+                              ...blockingCategoryOptionConsistencyErrors,
+                              ...pathogenAntibioticErrors,
+                              ...specimenPathogenErrors,
+                              ...astResultsErrors,
+                              ...batchIdErrors,
+                              ...yearErrors,
+                              ...countryErrors,
+                              ...duplicateRowErrors,
+                          ];
 
                 if (allBlockingErrors.length > 0) {
                     const errorImportSummary: ImportSummary = {
@@ -177,7 +180,7 @@ export class ImportRISFile {
                                             rulesInstructions
                                         );
 
-                                        const importSummary = mapDataValuesToImportSummary(saveSummary);
+                                        const importSummary = mapDataValuesToImportSummary(saveSummary, action);
 
                                         const summaryWithConsistencyBlokingErrors = includeBlockingErrors(
                                             importSummary,
@@ -192,7 +195,7 @@ export class ImportRISFile {
                     }
                     //If dry-run, do not run validations
                     else {
-                        const importSummary = mapDataValuesToImportSummary(saveSummary);
+                        const importSummary = mapDataValuesToImportSummary(saveSummary, action);
 
                         const summaryWithConsistencyBlokingErrors = includeBlockingErrors(importSummary, [
                             ...allBlockingErrors,

--- a/src/domain/usecases/data-entry/amr/ImportSampleFile.ts
+++ b/src/domain/usecases/data-entry/amr/ImportSampleFile.ts
@@ -114,15 +114,23 @@ export class ImportSampleFile {
                                 .map(rulesInstructions => {
                                     const dhis2ValidationErrors = checkDhis2Validations(validations, rulesInstructions);
 
-                                    const importSummary = mapDataValuesToImportSummary(saveSummary);
+                                    const importSummary = mapDataValuesToImportSummary(saveSummary, action);
 
-                                    const summaryWithConsistencyBlokingErrors = includeBlockingErrors(importSummary, [
-                                        ...batchIdErrors,
-                                        ...yearErrors,
-                                        ...countryErrors,
-                                        ...dhis2ValidationErrors,
-                                        ...duplicateRowErrors,
-                                    ]);
+                                    const allBlockingErrors =
+                                        action === "DELETE" //If delete, ignore consistency checks
+                                            ? []
+                                            : [
+                                                  ...batchIdErrors,
+                                                  ...yearErrors,
+                                                  ...countryErrors,
+                                                  ...dhis2ValidationErrors,
+                                                  ...duplicateRowErrors,
+                                              ];
+
+                                    const summaryWithConsistencyBlokingErrors = includeBlockingErrors(
+                                        importSummary,
+                                        allBlockingErrors
+                                    );
 
                                     return summaryWithConsistencyBlokingErrors;
                                 });

--- a/src/domain/usecases/data-entry/utils/mapDhis2Summary.ts
+++ b/src/domain/usecases/data-entry/utils/mapDhis2Summary.ts
@@ -1,8 +1,11 @@
 import i18n from "@eyeseetea/d2-ui-components/locales";
-import { DataValuesSaveSummary } from "../../../entities/data-entry/DataValuesSaveSummary";
+import { DataValuesSaveSummary, ImportStrategy } from "../../../entities/data-entry/DataValuesSaveSummary";
 import { ImportSummary } from "../../../entities/data-entry/ImportSummary";
 
-export function mapDataValuesToImportSummary(dhis2Summary: DataValuesSaveSummary): ImportSummary {
+export function mapDataValuesToImportSummary(
+    dhis2Summary: DataValuesSaveSummary,
+    action: ImportStrategy
+): ImportSummary {
     const nonBlockingErrors =
         dhis2Summary.status === "WARNING"
             ? dhis2Summary.conflicts?.map(status => {
@@ -24,7 +27,7 @@ export function mapDataValuesToImportSummary(dhis2Summary: DataValuesSaveSummary
             : [];
 
     const ignoredErrors =
-        dhis2Summary.importCount.ignored > 0
+        action !== "DELETE" && dhis2Summary.importCount.ignored > 0 //If delete, ignore import ignored errors.
             ? dhis2Summary.conflicts && dhis2Summary.conflicts.length > 0
                 ? dhis2Summary.conflicts?.map(status => {
                       return {


### PR DESCRIPTION
…red' error

### :pushpin: References

-   **Issue:** Closes #?


### :memo: Implementation
1. On delete action, do not run consistency checks
2. On delete action, even if some imports are ignored, do not show error. 
### :video_camera: Screenshots/Screen capture

### :fire: Testing
