### PR TITLE
Fix wrong type of tests data for substance calculations tests

### DIFF
--- a/src/domain/usecases/data-entry/amc/utils/__tests__/data/rawSubstanceConsumptionDataAtcNotFound.json
+++ b/src/domain/usecases/data-entry/amc/utils/__tests__/data/rawSubstanceConsumptionDataAtcNotFound.json
@@ -1,6 +1,6 @@
 [
     {
-        "eventId": "H1WH9fSpzRN",
+        "id": "H1WH9fSpzRN",
         "data_status_manual": 1,
         "salt_manual": "XXXX",
         "atc_version_manual": "ATC-2023-v1",
@@ -14,7 +14,7 @@
         "report_date": "2023-01-01"
     },
     {
-        "eventId": "GPq4pzoqCJP",
+        "id": "GPq4pzoqCJP",
         "data_status_manual": 1,
         "route_admin_manual": "O",
         "atc_manual": "J01FA01",
@@ -28,7 +28,7 @@
         "report_date": "2023-01-01"
     },
     {
-        "eventId": "oDa3g1oeT2A",
+        "id": "oDa3g1oeT2A",
         "ddds_manual": 50994.6666666667,
         "data_status_manual": 1,
         "atc_manual": "J01CR02",
@@ -42,7 +42,7 @@
         "report_date": "2023-01-01"
     },
     {
-        "eventId": "mfYlg4xTJzZ",
+        "id": "mfYlg4xTJzZ",
         "packages_manual": 90169,
         "data_status_manual": 1,
         "route_admin_manual": "O",
@@ -56,7 +56,7 @@
         "report_date": "2023-01-01"
     },
     {
-        "eventId": "tpcIHEdyjN7",
+        "id": "tpcIHEdyjN7",
         "ddds_manual": 405,
         "route_admin_manual": "O",
         "atc_version_manual": "ATC-2022-v2",
@@ -70,7 +70,7 @@
         "report_date": "2023-01-01"
     },
     {
-        "eventId": "UtHEvI6BQdT",
+        "id": "UtHEvI6BQdT",
         "atc_version_manual": "ATC-2021-v1",
         "route_admin_manual": "O",
         "ddds_manual": 21641774,
@@ -84,7 +84,7 @@
         "report_date": "2023-01-01"
     },
     {
-        "eventId": "U8GcL74VNw3",
+        "id": "U8GcL74VNw3",
         "atc_version_manual": "ATC-2021-v1",
         "ddds_manual": 510780.774,
         "tons_manual": 0.510780774,
@@ -98,7 +98,7 @@
         "report_date": "2023-01-01"
     },
     {
-        "eventId": "ypCmO6ukcAB",
+        "id": "ypCmO6ukcAB",
         "route_admin_manual": "O",
         "salt_manual": "HIPP",
         "packages_manual": 104843,
@@ -112,7 +112,7 @@
         "report_date": "2023-01-01"
     },
     {
-        "eventId": "vLKUOdmKdOP",
+        "id": "vLKUOdmKdOP",
         "ddds_manual": 17525.1666666667,
         "atc_manual": "J01CE01",
         "salt_manual": "XXXX",
@@ -126,7 +126,7 @@
         "report_date": "2023-01-01"
     },
     {
-        "eventId": "cwXyXFIGgDh",
+        "id": "cwXyXFIGgDh",
         "atc_manual": "J01CR02",
         "packages_manual": 15241,
         "tons_manual": 0.0889058333333333,
@@ -140,7 +140,7 @@
         "report_date": "2023-01-01"
     },
     {
-        "eventId": "sXalPksBKZR",
+        "id": "sXalPksBKZR",
         "salt_manual": "XXXX",
         "atc_version_manual": "ATC-2021-v1",
         "ddds_manual": 287862.5,
@@ -154,7 +154,7 @@
         "report_date": "2023-01-01"
     },
     {
-        "eventId": "gS5hoCfREtQ",
+        "id": "gS5hoCfREtQ",
         "salt_manual": "XXXX",
         "ddds_manual": 280,
         "atc_manual": "J01CR02",
@@ -168,7 +168,7 @@
         "report_date": "2023-01-01"
     },
     {
-        "eventId": "SYEDRojebUL",
+        "id": "SYEDRojebUL",
         "salt_manual": "XXXX",
         "packages_manual": 1020,
         "atc_version_manual": "ATC-2022-v2",
@@ -182,7 +182,7 @@
         "report_date": "2023-01-01"
     },
     {
-        "eventId": "ldXpFeOZVfQ",
+        "id": "ldXpFeOZVfQ",
         "salt_manual": "XXXX",
         "health_sector_manual": "PUB",
         "tons_manual": 0.0000504,
@@ -196,7 +196,7 @@
         "report_date": "2023-01-01"
     },
     {
-        "eventId": "zrWTFUXiZQk",
+        "id": "zrWTFUXiZQk",
         "health_level_manual": "C",
         "salt_manual": "XXXX",
         "health_sector_manual": "PUB",

--- a/src/domain/usecases/data-entry/amc/utils/__tests__/data/rawSubstanceConsumptionDataBasic.json
+++ b/src/domain/usecases/data-entry/amc/utils/__tests__/data/rawSubstanceConsumptionDataBasic.json
@@ -1,6 +1,6 @@
 [
     {
-        "eventId": "H1WH9fSpzRN",
+        "id": "H1WH9fSpzRN",
         "data_status_manual": 1,
         "salt_manual": "XXXX",
         "atc_version_manual": "ATC-2023-v1",
@@ -14,7 +14,7 @@
         "report_date": "2023-01-01"
     },
     {
-        "eventId": "GPq4pzoqCJP",
+        "id": "GPq4pzoqCJP",
         "data_status_manual": 1,
         "route_admin_manual": "O",
         "atc_manual": "J01FA01",
@@ -28,7 +28,7 @@
         "report_date": "2023-01-01"
     },
     {
-        "eventId": "oDa3g1oeT2A",
+        "id": "oDa3g1oeT2A",
         "ddds_manual": 50994.6666666667,
         "data_status_manual": 1,
         "atc_manual": "J01CR02",
@@ -42,7 +42,7 @@
         "report_date": "2023-01-01"
     },
     {
-        "eventId": "mfYlg4xTJzZ",
+        "id": "mfYlg4xTJzZ",
         "packages_manual": 90169,
         "data_status_manual": 1,
         "route_admin_manual": "O",
@@ -56,7 +56,7 @@
         "report_date": "2023-01-01"
     },
     {
-        "eventId": "UtHEvI6BQdT",
+        "id": "UtHEvI6BQdT",
         "atc_version_manual": "ATC-2021-v1",
         "route_admin_manual": "O",
         "ddds_manual": 21641774,
@@ -70,7 +70,7 @@
         "report_date": "2023-01-01"
     },
     {
-        "eventId": "U8GcL74VNw3",
+        "id": "U8GcL74VNw3",
         "atc_version_manual": "ATC-2021-v1",
         "ddds_manual": 510780.774,
         "tons_manual": 0.510780774,
@@ -84,7 +84,7 @@
         "report_date": "2023-01-01"
     },
     {
-        "eventId": "ypCmO6ukcAB",
+        "id": "ypCmO6ukcAB",
         "route_admin_manual": "O",
         "salt_manual": "HIPP",
         "packages_manual": 104843,
@@ -98,7 +98,7 @@
         "report_date": "2023-01-01"
     },
     {
-        "eventId": "vLKUOdmKdOP",
+        "id": "vLKUOdmKdOP",
         "ddds_manual": 17525.1666666667,
         "atc_manual": "J01CE01",
         "salt_manual": "XXXX",
@@ -112,7 +112,7 @@
         "report_date": "2023-01-01"
     },
     {
-        "eventId": "cwXyXFIGgDh",
+        "id": "cwXyXFIGgDh",
         "atc_manual": "J01CR02",
         "packages_manual": 15241,
         "tons_manual": 0.0889058333333333,
@@ -126,7 +126,7 @@
         "report_date": "2023-01-01"
     },
     {
-        "eventId": "sXalPksBKZR",
+        "id": "sXalPksBKZR",
         "salt_manual": "XXXX",
         "atc_version_manual": "ATC-2021-v1",
         "ddds_manual": 287862.5,
@@ -140,7 +140,7 @@
         "report_date": "2023-01-01"
     },
     {
-        "eventId": "gS5hoCfREtQ",
+        "id": "gS5hoCfREtQ",
         "salt_manual": "XXXX",
         "ddds_manual": 280,
         "atc_manual": "J01CR02",
@@ -154,7 +154,7 @@
         "report_date": "2023-01-01"
     },
     {
-        "eventId": "SYEDRojebUL",
+        "id": "SYEDRojebUL",
         "salt_manual": "XXXX",
         "packages_manual": 1020,
         "atc_version_manual": "ATC-2022-v2",
@@ -168,7 +168,7 @@
         "report_date": "2023-01-01"
     },
     {
-        "eventId": "zrWTFUXiZQk",
+        "id": "zrWTFUXiZQk",
         "health_level_manual": "C",
         "salt_manual": "XXXX",
         "health_sector_manual": "PUB",


### PR DESCRIPTION
### :pushpin: References

### :memo: Implementation

- [Fix wrong type of tests data for substance calculations tests](https://github.com/EyeSeeTea/glass-dev/commit/6262ab366313049e9952b48f779520f309b32e26)

### :video_camera: Screenshots/Screen capture

### :fire: Testing
