### PR TITLE
Added auth validation

### DIFF
--- a/src/scripts/amr_agg_data_reset.ts
+++ b/src/scripts/amr_agg_data_reset.ts
@@ -31,11 +31,17 @@ function main() {
             if (!process.env.REACT_APP_DHIS2_AUTH)
                 throw new Error("REACT_APP_DHIS2_BASE_URL  must be set in the .env file");
 
+            const username = process.env.REACT_APP_DHIS2_AUTH.split(":")[0] ?? "";
+            const password = process.env.REACT_APP_DHIS2_AUTH.split(":")[1] ?? "";
+
+            if (username === "" || password === "") {
+                throw new Error("REACT_APP_DHIS2_AUTH must be in the format 'username:password'");
+            }
             const envVars = {
                 url: process.env.REACT_APP_DHIS2_BASE_URL,
                 auth: {
-                    username: process.env.REACT_APP_DHIS2_AUTH.split(":")[0],
-                    password: process.env.REACT_APP_DHIS2_AUTH.split(":")[1],
+                    username: username,
+                    password: password,
                 },
             };
 

--- a/src/scripts/amr_agg_data_reset_sample.ts
+++ b/src/scripts/amr_agg_data_reset_sample.ts
@@ -31,14 +31,19 @@ function main() {
             if (!process.env.REACT_APP_DHIS2_AUTH)
                 throw new Error("REACT_APP_DHIS2_BASE_URL  must be set in the .env file");
 
+            const username = process.env.REACT_APP_DHIS2_AUTH.split(":")[0] ?? "";
+            const password = process.env.REACT_APP_DHIS2_AUTH.split(":")[1] ?? "";
+
+            if (username === "" || password === "") {
+                throw new Error("REACT_APP_DHIS2_AUTH must be in the format 'username:password'");
+            }
             const envVars = {
                 url: process.env.REACT_APP_DHIS2_BASE_URL,
                 auth: {
-                    username: process.env.REACT_APP_DHIS2_AUTH.split(":")[0],
-                    password: process.env.REACT_APP_DHIS2_AUTH.split(":")[1],
+                    username: username,
+                    password: password,
                 },
             };
-
             const api = getD2ApiFromArgs(envVars);
 
             //1. Get Period for which to reset.

--- a/src/scripts/amr_agg_data_validation.ts
+++ b/src/scripts/amr_agg_data_validation.ts
@@ -25,11 +25,17 @@ function main() {
             if (!process.env.REACT_APP_DHIS2_AUTH)
                 throw new Error("REACT_APP_DHIS2_BASE_URL  must be set in the .env file");
 
+            const username = process.env.REACT_APP_DHIS2_AUTH.split(":")[0] ?? "";
+            const password = process.env.REACT_APP_DHIS2_AUTH.split(":")[1] ?? "";
+
+            if (username === "" || password === "") {
+                throw new Error("REACT_APP_DHIS2_AUTH must be in the format 'username:password'");
+            }
             const envVars = {
                 url: process.env.REACT_APP_DHIS2_BASE_URL,
                 auth: {
-                    username: process.env.REACT_APP_DHIS2_AUTH.split(":")[0],
-                    password: process.env.REACT_APP_DHIS2_AUTH.split(":")[1],
+                    username: username,
+                    password: password,
                 },
             };
 

--- a/src/scripts/amr_agg_data_validation_sample.ts
+++ b/src/scripts/amr_agg_data_validation_sample.ts
@@ -24,11 +24,17 @@ function main() {
             if (!process.env.REACT_APP_DHIS2_AUTH)
                 throw new Error("REACT_APP_DHIS2_BASE_URL  must be set in the .env file");
 
+            const username = process.env.REACT_APP_DHIS2_AUTH.split(":")[0] ?? "";
+            const password = process.env.REACT_APP_DHIS2_AUTH.split(":")[1] ?? "";
+
+            if (username === "" || password === "") {
+                throw new Error("REACT_APP_DHIS2_AUTH must be in the format 'username:password'");
+            }
             const envVars = {
                 url: process.env.REACT_APP_DHIS2_BASE_URL,
                 auth: {
-                    username: process.env.REACT_APP_DHIS2_AUTH.split(":")[0],
-                    password: process.env.REACT_APP_DHIS2_AUTH.split(":")[1],
+                    username: username,
+                    password: password,
                 },
             };
 


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #?
Fixes TS2345 type error, which prevents the code from compiling.


Ensure auth credentials are defined before passing to D2ApiArgs

This PR addresses an issue where `username` and `password` could be `undefined`, causing a type error. The solution ensures that both `username` and `password` are defined before passing them to `D2ApiArgs`.

- Used nullish coalescing operator (??) to provide default empty string values if `username` or `password` are `undefined`.


### :memo: Implementation

### :video_camera: Screenshots/Screen capture

### :fire: Testing
