### PR TITLE
Bug: Upload substance data: 0 errors but cannot continue

### DIFF
--- a/src/domain/usecases/data-entry/egasp/CustomValidationForEventProgram.ts
+++ b/src/domain/usecases/data-entry/egasp/CustomValidationForEventProgram.ts
@@ -48,7 +48,10 @@ export class CustomValidationForEventProgram {
 
                 const results: ValidationResult = {
                     events: events,
-                    blockingErrors: [...orgUnitErrors, ...periodErrors, atcVersionKeyError],
+                    blockingErrors:
+                        !atcVersionKeyError.count && !atcVersionKeyError.error && !atcVersionKeyError.lines?.length
+                            ? [...orgUnitErrors, ...periodErrors]
+                            : [...orgUnitErrors, ...periodErrors, atcVersionKeyError],
                     nonBlockingErrors: [],
                 };
 


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #86952w25p [Bug: Upload substance data: 0 errors but cannot continue](https://app.clickup.com/t/86952w25p)

### :memo: Implementation
- Check if there are any error before add ATC error to blocking errors array

### :video_camera: Screenshots/Screen capture
![Screenshot from 2024-07-16 15-11-05](https://github.com/user-attachments/assets/d61073c0-1fee-4b6c-ae54-4f55f199c7d2)

### :fire: Testing
[AMC-Substance Level Data-FRA-TEMPLATE (2).xlsx](https://github.com/user-attachments/files/16249359/AMC-Substance.Level.Data-FRA-TEMPLATE.2.xlsx)

