### PR TITLE
Bug: ATCVersion substance level data

### DIFF
--- a/src/CompositionRoot.ts
+++ b/src/CompositionRoot.ts
@@ -188,7 +188,8 @@ export function getCompositionRoot(instance: Instance) {
                 programRulesMetadataDefaultRepository,
                 atcRepository,
                 amcProductDataRepository,
-                amcSubstanceDataRepository
+                amcSubstanceDataRepository,
+                glassAtcRepository
             ),
             validatePrimaryFile: new ValidatePrimaryFileUseCase(
                 risDataRepository,
@@ -206,7 +207,8 @@ export function getCompositionRoot(instance: Instance) {
                 glassDocumentsRepository,
                 glassUploadsRepository,
                 dhis2EventsDefaultRepository,
-                programRulesMetadataDefaultRepository
+                programRulesMetadataDefaultRepository,
+                glassAtcRepository
             ),
             validateSecondaryFile: new ValidateSampleFileUseCase(
                 sampleDataRepository,

--- a/src/domain/entities/GlassAtcVersionData.ts
+++ b/src/domain/entities/GlassAtcVersionData.ts
@@ -19,6 +19,8 @@ export const DEFAULT_SALT_CODE = "XXXX";
 export const CODE_PRODUCT_NOT_HAVE_ATC = "Z99ZZ99";
 export const COMB_CODE_PRODUCT_NOT_HAVE_ATC = "Z99ZZ99_99";
 
+export type ATCVersionKey = string;
+
 export type ATCCodeLevel5 = string;
 
 export type RouteOfAdministrationCode = string;
@@ -185,15 +187,22 @@ export type GlassAtcVersionData = AtcDddIndexData & {
     aware_classification: AwareClassificationData;
 };
 
-export type ListGlassATCVersions = Record<string, GlassAtcVersionData>;
+export type ListGlassATCVersions = Record<ATCVersionKey, GlassAtcVersionData>;
 
-export function validateAtcVersion(atcVersionKey: string): boolean {
+export type ListGlassATCLastVersionKeysByYear = Record<string, ATCVersionKey>;
+
+export function validateAtcVersion(atcVersionKey: ATCVersionKey): boolean {
     const pattern = /^ATC-\d{4}-v\d+$/;
     return pattern.test(atcVersionKey);
 }
 
-export function createAtcVersionKey(year: number, version: number): string {
+export function createAtcVersionKey(year: number, version: number): ATCVersionKey {
     return `ATC-${year.toString()}-v${version.toString()}`;
+}
+
+export function getYearFromAtcVersionKey(key: ATCVersionKey): number | undefined {
+    const year = key.split("-")[1];
+    if (year) return parseInt(year);
 }
 
 export function getDDDChanges(changesData: ATCAndDDDChangesData[]): DDDChangesData[] {

--- a/src/domain/entities/data-entry/amc/RawSubstanceConsumptionCalculated.ts
+++ b/src/domain/entities/data-entry/amc/RawSubstanceConsumptionCalculated.ts
@@ -1,6 +1,7 @@
 import { Maybe } from "../../../../types/utils";
 import {
     ATCCodeLevel5,
+    ATCVersionKey,
     AmName,
     AwrName,
     RouteOfAdministrationCode,
@@ -59,7 +60,7 @@ export type RawSubstanceConsumptionCalculated = {
     health_level_autocalculated: string;
     tons_autocalculated: number;
     packages_autocalculated: number;
-    atc_version_autocalculated: string;
+    atc_version_autocalculated: ATCVersionKey;
     ddds_autocalculated: number;
     am_class: Maybe<AmName>;
     atc2: Maybe<string>;

--- a/src/domain/entities/data-entry/amc/SubstanceConsumptionCalculated.ts
+++ b/src/domain/entities/data-entry/amc/SubstanceConsumptionCalculated.ts
@@ -1,5 +1,12 @@
 import { Maybe } from "../../../../types/utils";
-import { ATCCodeLevel5, AmName, AwrName, RouteOfAdministrationCode, SaltCode } from "../../GlassAtcVersionData";
+import {
+    ATCCodeLevel5,
+    ATCVersionKey,
+    AmName,
+    AwrName,
+    RouteOfAdministrationCode,
+    SaltCode,
+} from "../../GlassAtcVersionData";
 import { Id } from "../../Ref";
 
 export type SubstanceConsumptionCalculated = {
@@ -8,7 +15,7 @@ export type SubstanceConsumptionCalculated = {
     salt_autocalculated: SaltCode;
     packages_autocalculated: number;
     ddds_autocalculated: number;
-    atc_version_autocalculated: string;
+    atc_version_autocalculated: ATCVersionKey;
     tons_autocalculated: number;
     data_status_autocalculated: number;
     health_sector_autocalculated: string;

--- a/src/domain/repositories/GlassATCRepository.ts
+++ b/src/domain/repositories/GlassATCRepository.ts
@@ -1,8 +1,10 @@
 import { FutureData } from "../entities/Future";
 import {
+    ATCVersionKey,
     GlassATCHistory,
     GlassATCRecalculateDataInfo,
     GlassAtcVersionData,
+    ListGlassATCLastVersionKeysByYear,
     ListGlassATCVersions,
 } from "../entities/GlassAtcVersionData";
 
@@ -13,4 +15,6 @@ export interface GlassATCRepository {
     getListOfAtcVersionsByKeys(atcVersionKeys: string[]): FutureData<ListGlassATCVersions>;
     getRecalculateDataInfo(): FutureData<GlassATCRecalculateDataInfo | undefined>;
     disableRecalculations(): FutureData<void>;
+    getLastAtcVersionKeyYear(year: string): FutureData<ATCVersionKey>;
+    getListOfLastAtcVersionsKeysByYears(years: string[]): FutureData<ListGlassATCLastVersionKeysByYear>;
 }

--- a/src/domain/usecases/data-entry/ImportPrimaryFileUseCase.tsx
+++ b/src/domain/usecases/data-entry/ImportPrimaryFileUseCase.tsx
@@ -39,7 +39,8 @@ export class ImportPrimaryFileUseCase {
         private programRulesMetadataRepository: ProgramRulesMetadataRepository,
         private atcRepository: GlassATCDefaultRepository,
         private amcProductRepository: AMCProductDataRepository,
-        private amcSubstanceDataRepository: AMCSubstanceDataRepository
+        private amcSubstanceDataRepository: AMCSubstanceDataRepository,
+        private glassAtcRepository: GlassATCDefaultRepository
     ) {}
 
     public execute(
@@ -74,7 +75,8 @@ export class ImportPrimaryFileUseCase {
                     this.glassUploadsRepository,
                     this.programRulesMetadataRepository,
                     this.metadataRepository,
-                    this.instanceRepository
+                    this.instanceRepository,
+                    this.glassAtcRepository
                 );
 
                 return importEGASPFile.importEGASPFile(

--- a/src/domain/usecases/data-entry/ImportSecondaryFileUseCase.tsx
+++ b/src/domain/usecases/data-entry/ImportSecondaryFileUseCase.tsx
@@ -13,6 +13,7 @@ import { GlassDocumentsDefaultRepository } from "../../../data/repositories/Glas
 import { GlassUploadsRepository } from "../../repositories/GlassUploadsRepository";
 import { Dhis2EventsDefaultRepository } from "../../../data/repositories/Dhis2EventsDefaultRepository";
 import { ProgramRulesMetadataRepository } from "../../repositories/program-rules/ProgramRulesMetadataRepository";
+import { GlassATCDefaultRepository } from "../../../data/repositories/GlassATCDefaultRepository";
 
 export class ImportSecondaryFileUseCase implements UseCase {
     constructor(
@@ -24,7 +25,8 @@ export class ImportSecondaryFileUseCase implements UseCase {
         private glassDocumentsRepository: GlassDocumentsDefaultRepository,
         private glassUploadsRepository: GlassUploadsRepository,
         private dhis2EventsDefaultRepository: Dhis2EventsDefaultRepository,
-        private programRulesMetadataRepository: ProgramRulesMetadataRepository
+        private programRulesMetadataRepository: ProgramRulesMetadataRepository,
+        private glassAtcRepository: GlassATCDefaultRepository
     ) {}
 
     public execute(
@@ -59,7 +61,8 @@ export class ImportSecondaryFileUseCase implements UseCase {
                     this.glassUploadsRepository,
                     this.dhis2EventsDefaultRepository,
                     this.metadataRepository,
-                    this.programRulesMetadataRepository
+                    this.programRulesMetadataRepository,
+                    this.glassAtcRepository
                 );
                 return importRawSubstanceData.import(
                     inputFile,

--- a/src/domain/usecases/data-entry/amc/ImportAMCSubstanceLevelData.ts
+++ b/src/domain/usecases/data-entry/amc/ImportAMCSubstanceLevelData.ts
@@ -9,6 +9,7 @@ import { Dhis2EventsDefaultRepository } from "../../../../data/repositories/Dhis
 import { MetadataRepository } from "../../../repositories/MetadataRepository";
 import { ImportBLTemplateEventProgram } from "../ImportBLTemplateEventProgram";
 import { ProgramRulesMetadataRepository } from "../../../repositories/program-rules/ProgramRulesMetadataRepository";
+import { GlassATCDefaultRepository } from "../../../../data/repositories/GlassATCDefaultRepository";
 
 export const AMC_RAW_SUBSTANCE_CONSUMPTION_PROGRAM_ID = "q8aSKr17J5S";
 export const AMC_SUBSTANCE_CALCULATED_CONSUMPTION_PROGRAM_ID = "eUmWZeKZNrg";
@@ -21,7 +22,8 @@ export class ImportAMCSubstanceLevelData {
         private glassUploadsRepository: GlassUploadsRepository,
         private dhis2EventsDefaultRepository: Dhis2EventsDefaultRepository,
         private metadataRepository: MetadataRepository,
-        private programRulesMetadataRepository: ProgramRulesMetadataRepository
+        private programRulesMetadataRepository: ProgramRulesMetadataRepository,
+        private glassAtcRepository: GlassATCDefaultRepository
     ) {}
 
     public import(
@@ -41,7 +43,8 @@ export class ImportAMCSubstanceLevelData {
             this.glassUploadsRepository,
             this.dhis2EventsDefaultRepository,
             this.metadataRepository,
-            this.programRulesMetadataRepository
+            this.programRulesMetadataRepository,
+            this.glassAtcRepository
         );
 
         return importBLTemplateEventProgram.import(

--- a/src/domain/usecases/data-entry/amc/utils/calculationConsumptionSubstanceLevelData.ts
+++ b/src/domain/usecases/data-entry/amc/utils/calculationConsumptionSubstanceLevelData.ts
@@ -70,8 +70,7 @@ export function calculateConsumptionSubstanceLevelData(
             );
 
             calculationLogs = [...calculationLogs, ...dddStandarizedLatest.logs];
-
-            if (!dddStandarizedLatest.result) {
+            if (!dddStandarizedLatest.result && dddStandarizedLatest.result !== 0) {
                 calculationLogs = [
                     ...calculationLogs,
                     {
@@ -102,7 +101,10 @@ export function calculateConsumptionSubstanceLevelData(
             );
             calculationLogs = [...calculationLogs, ...dddStandarizedInRawSubstanceConsumption.logs];
 
-            if (!dddStandarizedInRawSubstanceConsumption.result) {
+            if (
+                !dddStandarizedInRawSubstanceConsumption.result &&
+                dddStandarizedInRawSubstanceConsumption.result !== 0
+            ) {
                 calculationLogs = [
                     ...calculationLogs,
                     {

--- a/src/domain/usecases/data-entry/egasp/CustomValidationForEventProgram.ts
+++ b/src/domain/usecases/data-entry/egasp/CustomValidationForEventProgram.ts
@@ -8,6 +8,7 @@ import { MetadataRepository } from "../../../repositories/MetadataRepository";
 import { AMC_RAW_SUBSTANCE_CONSUMPTION_PROGRAM_ID } from "../amc/ImportAMCSubstanceLevelData";
 import { EGASP_PROGRAM_ID } from "../../../../data/repositories/program-rule/ProgramRulesMetadataDefaultRepository";
 import { validateAtcVersion } from "../../../entities/GlassAtcVersionData";
+import { GlassATCDefaultRepository } from "../../../../data/repositories/GlassATCDefaultRepository";
 
 const EGASP_DATAELEMENT_ID = "KaS2YBRN8eH";
 const PATIENT_DATAELEMENT_ID = "aocFHBxcQa0";
@@ -15,7 +16,8 @@ const ATC_VERSION_DATAELEMENT_ID = "aCuWz3HZ5Ti";
 export class CustomValidationForEventProgram {
     constructor(
         private dhis2EventsDefaultRepository: Dhis2EventsDefaultRepository,
-        private metadataRepository: MetadataRepository
+        private metadataRepository: MetadataRepository,
+        private glassAtcRepository: GlassATCDefaultRepository
     ) {}
     public getValidatedEvents(
         events: Event[],
@@ -29,7 +31,6 @@ export class CustomValidationForEventProgram {
         return this.checkCountry(events, orgUnitId, orgUnitName, checkClinics).flatMap(orgUnitErrors => {
             //2. Period validation
             const periodErrors = this.checkPeriod(events, period);
-
             if (programId === AMC_RAW_SUBSTANCE_CONSUMPTION_PROGRAM_ID) {
                 const initialErrors: ConsistencyError = { error: "", count: 0, lines: [] };
                 const atcVersionKeyError: ConsistencyError = events.reduce((acc, event) => {
@@ -40,7 +41,7 @@ export class CustomValidationForEventProgram {
                         ? acc
                         : {
                               ...acc,
-                              error: "ATC version manual has not the correct format (example: ATC-2024-v1)",
+                              error: "There is not an ATC version data for the corresponding year in ATC version manual",
                               count: acc?.count + 1,
                               lines: [...(acc?.lines || []), parseInt(event.event)],
                           };

--- a/src/domain/usecases/data-entry/egasp/ImportEGASPFile.ts
+++ b/src/domain/usecases/data-entry/egasp/ImportEGASPFile.ts
@@ -10,6 +10,7 @@ import { MetadataRepository } from "../../../repositories/MetadataRepository";
 import { EGASP_PROGRAM_ID } from "../../../../data/repositories/program-rule/ProgramRulesMetadataDefaultRepository";
 import { InstanceDefaultRepository } from "../../../../data/repositories/InstanceDefaultRepository";
 import { ImportBLTemplateEventProgram } from "../ImportBLTemplateEventProgram";
+import { GlassATCDefaultRepository } from "../../../../data/repositories/GlassATCDefaultRepository";
 
 export class ImportEGASPFile {
     constructor(
@@ -20,7 +21,8 @@ export class ImportEGASPFile {
         private glassUploadsRepository: GlassUploadsRepository,
         private programRulesMetadataRepository: ProgramRulesMetadataRepository,
         private metadataRepository: MetadataRepository,
-        private instanceRepository: InstanceDefaultRepository
+        private instanceRepository: InstanceDefaultRepository,
+        private glassAtcRepository: GlassATCDefaultRepository
     ) {}
 
     public importEGASPFile(
@@ -39,7 +41,8 @@ export class ImportEGASPFile {
             this.glassUploadsRepository,
             this.dhis2EventsDefaultRepository,
             this.metadataRepository,
-            this.programRulesMetadataRepository
+            this.programRulesMetadataRepository,
+            this.glassAtcRepository
         );
 
         return importBLTemplateEventProgram.import(


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #86952w1wd [Bug: ATCVersion substance level data](https://app.clickup.com/t/86952w1wd)

### :memo: Implementation
- Allow to upload year in atc version manual for substance files and save the last atc version key in event program

### :video_camera: Screenshots/Screen capture
-Raw:
![Screenshot from 2024-07-18 15-59-46](https://github.com/user-attachments/assets/8d3e70dc-6a31-4ff9-8616-51d209c92b57)
![Screenshot from 2024-07-18 16-00-32](https://github.com/user-attachments/assets/23451a9b-f063-4dfc-be6a-f201e5b54b47)

- Calculated:
![Screenshot from 2024-07-18 15-59-49](https://github.com/user-attachments/assets/f17ff8f8-cdc5-4416-9cb5-496be4f386c0)

-Error:
![Screenshot from 2024-07-18 14-33-08](https://github.com/user-attachments/assets/3c1e74a3-c26b-4244-a6cb-d4d78556e4b0)


### :fire: Testing
[2018_AFG_NOT_OK_AMC-Substance Level Data-AFG-TEMPLATE.xlsx](https://github.com/user-attachments/files/16284384/2018_AFG_NOT_OK_AMC-Substance.Level.Data-AFG-TEMPLATE.xlsx)
[2018_AFG_OK_AMC-Substance Level Data-AFG-TEMPLATE.xlsx](https://github.com/user-attachments/files/16284385/2018_AFG_OK_AMC-Substance.Level.Data-AFG-TEMPLATE.xlsx)
