### PR TITLE
ATC Classification Updates for 2024

### DIFF
--- a/src/domain/entities/GlassAtcVersionData.ts
+++ b/src/domain/entities/GlassAtcVersionData.ts
@@ -274,16 +274,26 @@ export function getNewDddData(
 }
 
 export function getAmClass(amClassData: AmClassificationData, atcCode: ATCCodeLevel5): AmName | undefined {
-    const atcAwareCode = amClassData.atc_am_mapping.find(({ ATCS }) => {
-        return ATCS.some(atc => {
+    const atcAwareCodeFullyFound = amClassData.atc_am_mapping.find(({ ATCS }) =>
+        ATCS.some(atc => atcCode === atc)
+    )?.CODE;
+
+    if (atcAwareCodeFullyFound) {
+        return amClassData.classification.find(({ CODE }) => CODE === atcAwareCodeFullyFound)?.NAME;
+    }
+
+    const atcAwareCodeFoundByPrefix = amClassData.atc_am_mapping.find(({ ATCS }) =>
+        ATCS.some(atc => {
             if (atc.endsWith("*")) {
                 const prefix = atc.slice(0, -1);
                 return atcCode.startsWith(prefix);
             }
-            return atcCode === atc;
-        });
-    })?.CODE;
-    return amClassData.classification.find(({ CODE }) => CODE === atcAwareCode)?.NAME;
+        })
+    )?.CODE;
+
+    if (atcAwareCodeFoundByPrefix) {
+        return amClassData.classification.find(({ CODE }) => CODE === atcAwareCodeFoundByPrefix)?.NAME;
+    }
 }
 
 export function getAwareClass(awareClassData: AwareClassificationData, atcCode: ATCCodeLevel5): AwrName | undefined {


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #869567a21 [ATC Classification Updates for 2024](https://app.clickup.com/t/869567a21)

### :memo: Implementation
- Give priority to fully ATC codes in aware classification than atc prefixes: for instance J01XX05 is in OTH but J01XX05 still matches the rule for ATB (J01*). So giving the priority to full code, J01XX05 will be classified ad OTH not ATB.

### :video_camera: Screenshots/Screen capture

### :fire: Testing
