### PR TITLE
No error line number in concistency checks

### DIFF
--- a/src/domain/usecases/data-entry/egasp/CustomValidationForEventProgram.ts
+++ b/src/domain/usecases/data-entry/egasp/CustomValidationForEventProgram.ts
@@ -8,7 +8,6 @@ import { MetadataRepository } from "../../../repositories/MetadataRepository";
 import { AMC_RAW_SUBSTANCE_CONSUMPTION_PROGRAM_ID } from "../amc/ImportAMCSubstanceLevelData";
 import { EGASP_PROGRAM_ID } from "../../../../data/repositories/program-rule/ProgramRulesMetadataDefaultRepository";
 import { validateAtcVersion } from "../../../entities/GlassAtcVersionData";
-import { GlassATCDefaultRepository } from "../../../../data/repositories/GlassATCDefaultRepository";
 
 const EGASP_DATAELEMENT_ID = "KaS2YBRN8eH";
 const PATIENT_DATAELEMENT_ID = "aocFHBxcQa0";
@@ -16,8 +15,7 @@ const ATC_VERSION_DATAELEMENT_ID = "aCuWz3HZ5Ti";
 export class CustomValidationForEventProgram {
     constructor(
         private dhis2EventsDefaultRepository: Dhis2EventsDefaultRepository,
-        private metadataRepository: MetadataRepository,
-        private glassAtcRepository: GlassATCDefaultRepository
+        private metadataRepository: MetadataRepository
     ) {}
     public getValidatedEvents(
         events: Event[],


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #869565hb8 [No error line number in concistency checks](https://app.clickup.com/t/869565hb8)

### :memo: Implementation
- Add lines when there is an error in the ATC version manual

### :video_camera: Screenshots/Screen capture
BEFORE:
![Screenshot from 2024-07-24 15-41-02](https://github.com/user-attachments/assets/56ac8c55-0e51-43d7-be29-2c3f3a6f94d4)

AFTER:
![Screenshot from 2024-07-24 15-44-11](https://github.com/user-attachments/assets/da984e09-928b-4f46-935f-906db1234631)

### :fire: Testing
[WITH_ERRORS_AMC-Substance Level Data-AFG-TEMPLATE.xlsx](https://github.com/user-attachments/files/16363048/WITH_ERRORS_AMC-Substance.Level.Data-AFG-TEMPLATE.xlsx)

