### PR TITLE
Allow open periods from datastore

### DIFF
--- a/src/data/repositories/InstanceDefaultRepository.ts
+++ b/src/data/repositories/InstanceDefaultRepository.ts
@@ -85,6 +85,7 @@ export class InstanceDefaultRepository implements InstanceRepository {
                     moduleId: module.id,
                     moduleName: module.name,
                     populateCurrentYearInHistory: module.populateCurrentYearInHistory ? true : false,
+                    startPeriod: module.startPeriod,
                     readAccess: readAccess,
                     captureAccess: writeAccess,
                     usergroups: [...module.userGroups.captureAccess, ...module.userGroups.readAccess],

--- a/src/domain/entities/GlassModule.ts
+++ b/src/domain/entities/GlassModule.ts
@@ -43,6 +43,7 @@ export interface GlassModule {
         programStageId: string;
     }[];
     populateCurrentYearInHistory?: boolean;
+    startPeriod?: number;
     customDataColumns?: CustomDataColumns;
     lineLists?: LineListDetails[];
     chunkSizes?: ChunkSizes;

--- a/src/domain/entities/User.ts
+++ b/src/domain/entities/User.ts
@@ -22,6 +22,7 @@ export interface ModuleAccess {
     captureAccess: boolean;
     usergroups: UserGroup[];
     populateCurrentYearInHistory: boolean;
+    startPeriod?: number;
 }
 
 export interface UserAccessInfo {

--- a/src/utils/currentPeriodHelper.ts
+++ b/src/utils/currentPeriodHelper.ts
@@ -50,3 +50,7 @@ export const getLastNYearsQuarters = (n = 8) => {
 
     return years;
 };
+
+export const getRangeOfYears = (maxYear: number, minYear: number): string[] => {
+    return Array.from({ length: maxYear - minYear + 1 }, (_, i) => (maxYear - i).toString());
+};

--- a/src/webapp/components/data-file-history/Filter.tsx
+++ b/src/webapp/components/data-file-history/Filter.tsx
@@ -3,7 +3,12 @@ import { Box, FormControl, MenuItem, Select, Typography, InputLabel, withStyles,
 import { glassColors } from "../../pages/app/themes/dhis2.theme";
 import i18n from "@eyeseetea/d2-ui-components/locales";
 import { Dispatch, SetStateAction, useMemo } from "react";
-import { getLastNYears, getLastNYearsQuarters } from "../../../utils/currentPeriodHelper";
+import {
+    getCurrentYear,
+    getLastNYears,
+    getLastNYearsQuarters,
+    getRangeOfYears,
+} from "../../../utils/currentPeriodHelper";
 import { useCurrentModuleContext } from "../../contexts/current-module-context";
 import { useAppContext } from "../../contexts/app-context";
 
@@ -86,12 +91,18 @@ export const Filter: React.FC<FilterProps> = ({ year, setYear, status, setStatus
             return [...quarters, { label: "All", value: "All" }];
         } else {
             const addCurrentYear = currentModuleAccess.populateCurrentYearInHistory;
-            const years = getLastNYears(addCurrentYear).map(year => ({ label: year, value: year }));
-            return [...years, { label: "All", value: "All" }];
+            const years = currentModuleAccess.startPeriod
+                ? getRangeOfYears(
+                      addCurrentYear ? getCurrentYear() : getCurrentYear() - 1,
+                      currentModuleAccess.startPeriod
+                  )
+                : getLastNYears(addCurrentYear);
+            return [...years.map(year => ({ label: year, value: year })), { label: "All", value: "All" }];
         }
     }, [
         currentModuleAccess.moduleName,
         currentModuleAccess.populateCurrentYearInHistory,
+        currentModuleAccess.startPeriod,
         currentUser.quarterlyPeriodModules,
     ]);
 

--- a/src/webapp/components/data-submissions-history/hooks/usePopulateDataSubmissionHistory.ts
+++ b/src/webapp/components/data-submissions-history/hooks/usePopulateDataSubmissionHistory.ts
@@ -3,7 +3,12 @@ import { useAppContext } from "../../../contexts/app-context";
 import { useCurrentOrgUnitContext } from "../../../contexts/current-orgUnit-context";
 import { useCurrentModuleContext } from "../../../contexts/current-module-context";
 import { useGlassDataSubmissionsByModuleAndOU } from "../../../hooks/useGlassDataSubmissionsByModuleAndOU";
-import { getLastNYears, getLastNYearsQuarters } from "../../../../utils/currentPeriodHelper";
+import {
+    getCurrentYear,
+    getLastNYears,
+    getLastNYearsQuarters,
+    getRangeOfYears,
+} from "../../../../utils/currentPeriodHelper";
 
 export function usePopulateDataSubmissionHistory() {
     const { compositionRoot } = useAppContext();
@@ -31,11 +36,22 @@ export function usePopulateDataSubmissionHistory() {
             } else {
                 //Check if Data Submissions history is populated
                 const addCurrentYear = currentModuleAccess.populateCurrentYearInHistory;
-                getLastNYears(addCurrentYear).forEach(year => {
-                    if (!dataSubmissions.data.find(ds => ds.period === year)) {
-                        years.push(year);
-                    }
-                });
+                if (currentModuleAccess.startPeriod) {
+                    const maxYear = addCurrentYear ? getCurrentYear() : getCurrentYear() - 1;
+                    const minYear = currentModuleAccess.startPeriod;
+
+                    getRangeOfYears(maxYear, minYear).forEach(year => {
+                        if (!dataSubmissions.data.find(ds => ds.period === year)) {
+                            years.push(year);
+                        }
+                    });
+                } else {
+                    getLastNYears(addCurrentYear).forEach(year => {
+                        if (!dataSubmissions.data.find(ds => ds.period === year)) {
+                            years.push(year);
+                        }
+                    });
+                }
             }
 
             if (years.length && currentModuleAccess.moduleId !== "" && currentOrgUnitAccess.orgUnitId !== "") {
@@ -55,6 +71,7 @@ export function usePopulateDataSubmissionHistory() {
         }
     }, [
         compositionRoot.glassDataSubmission,
+        currentModuleAccess,
         currentModuleAccess.moduleId,
         currentModuleAccess.moduleName,
         currentModuleAccess.populateCurrentYearInHistory,


### PR DESCRIPTION
:warning: **ADD TO DATASTORE https://dev.eyeseetea.com/who-dev-238/dhis-web-datastore/index.html#/edit/glass/modules in AMC the startPeriod to open new period**

![image](https://github.com/user-attachments/assets/47f0cc33-2828-4846-a662-13eaa09d97cf)

### :pushpin: References

-   **Issue:** Closes #?

### :memo: Implementation
- Allow open periods from datastore

### :video_camera: Screenshots/Screen capture
https://dev.eyeseetea.com/who-dev-238/api/apps/glass/index.html#/current-data-submission/?period=2016&orgUnit=oofyLUJJ6Vy&module=AMC

![Screenshot from 2024-08-23 12-28-00](https://github.com/user-attachments/assets/b0c6898f-815b-4a8c-9c15-f24f2996b015)
![Screenshot from 2024-08-23 12-28-31](https://github.com/user-attachments/assets/aec87df4-fe2d-4ab1-9cd0-aff98047e40e)
![Screenshot from 2024-08-23 12-28-44](https://github.com/user-attachments/assets/e970ef40-fedb-45ee-8d05-9754c8455095)
![Screenshot from 2024-08-23 12-36-18](https://github.com/user-attachments/assets/92048aa5-afac-4ee0-af27-9db408a79241)



### :fire: Testing
[AMC-Product Level Data-AFG-TEMPLATE (1).xlsx](https://github.com/user-attachments/files/16727443/AMC-Product.Level.Data-AFG-TEMPLATE.1.xlsx)