### PR TITLE
fix: url too long fix + disable report bugs in prod

### DIFF
--- a/src/domain/usecases/data-entry/egasp/CustomValidationForEventProgram.ts
+++ b/src/domain/usecases/data-entry/egasp/CustomValidationForEventProgram.ts
@@ -95,7 +95,9 @@ export class CustomValidationForEventProgram {
         countryName: string,
         checkClinics: boolean
     ): FutureData<ConsistencyError[]> {
-        const clinicsInEvents = events.map(e => e.orgUnit);
+        const clinicsInEvents = _(events.map(e => e.orgUnit))
+            .uniq()
+            .value();
         return Future.joinObj({
             clinicsInCountry: checkClinics
                 ? this.metadataRepository.getClinicsAndLabsInOrgUnitId(countryId)

--- a/src/webapp/pages/app/App.tsx
+++ b/src/webapp/pages/app/App.tsx
@@ -40,7 +40,7 @@ export const App: React.FC<AppProps> = React.memo(function App({ api, d2, instan
 
             setAppContext({ api, currentUser, compositionRoot, instance: instance, allCountries: allCountries ?? [] });
             // setShowShareButton(isShareButtonVisible);
-            initFeedbackTool(d2, appConfig);
+            if (process.env.NODE_ENV !== "production") initFeedbackTool(d2, appConfig);
             setLoading(false);
         }
         setup();


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8695yrp78 , https://app.clickup.com/t/8694ze3uv, https://app.clickup.com/t/8695ynjk2, #8695yrp78, #8694ze3uv, #8695ynjk2

### :memo: Implementation
1. There was a bug in code where we were not filtering by unique clinics, so the clinic list is too long. This has been fixed.
2. Disable report bugs in prod env

### :video_camera: Screenshots/Screen capture

### :fire: Testing
