### PR TITLE
Fix mandatory fields for calculations and adapt code

### DIFF
--- a/src/domain/entities/data-entry/amc/ProductRegistryAttributes.ts
+++ b/src/domain/entities/data-entry/amc/ProductRegistryAttributes.ts
@@ -1,3 +1,4 @@
+import { Maybe } from "../../../../types/utils";
 import { UnitCode, RouteOfAdministrationCode, SaltCode } from "../../GlassAtcVersionData";
 
 export type ProductRegistryAttributes = {
@@ -5,12 +6,12 @@ export type ProductRegistryAttributes = {
     AMR_GLASS_AMC_TEA_PACKSIZE: number;
     AMR_GLASS_AMC_TEA_STRENGTH: number;
     AMR_GLASS_AMC_TEA_STRENGTH_UNIT: UnitCode;
-    AMR_GLASS_AMC_TEA_CONC_VOLUME: number;
+    AMR_GLASS_AMC_TEA_CONC_VOLUME: Maybe<number>;
     AMR_GLASS_AMC_TEA_ATC: string;
-    AMR_GLASS_AMC_TEA_COMBINATION?: string;
+    AMR_GLASS_AMC_TEA_COMBINATION: Maybe<string>;
     AMR_GLASS_AMC_TEA_ROUTE_ADMIN: RouteOfAdministrationCode;
     AMR_GLASS_AMC_TEA_SALT: SaltCode;
-    AMR_GLASS_AMC_TEA_VOLUME: number;
+    AMR_GLASS_AMC_TEA_VOLUME: Maybe<number>;
 };
 
 export const PRODUCT_REGISTRY_ATTRIBUTES_KEYS = [

--- a/src/domain/entities/data-entry/amc/RawProductConsumption.ts
+++ b/src/domain/entities/data-entry/amc/RawProductConsumption.ts
@@ -1,6 +1,8 @@
+import { Maybe } from "../../../../types/utils";
+
 export type RawProductConsumption = {
     AMR_GLASS_AMC_TEA_PRODUCT_ID: string;
-    packages_manual: number;
+    packages_manual: Maybe<number>;
     data_status_manual: number;
     health_sector_manual: string;
     health_level_manual: string;

--- a/src/domain/entities/data-entry/amc/RawSubstanceConsumptionCalculated.ts
+++ b/src/domain/entities/data-entry/amc/RawSubstanceConsumptionCalculated.ts
@@ -37,7 +37,7 @@ export type DDDPerProductConsumptionPackages = {
     year: string;
     health_sector_manual: string;
     health_level_manual: string;
-    dddConsumptionPackages: number;
+    dddConsumptionPackages: Maybe<number>;
     dddUnit: UnitCode;
 };
 
@@ -46,7 +46,7 @@ export type ContentTonnesPerProduct = {
     year: string;
     health_sector_manual: string;
     health_level_manual: string;
-    contentTonnes: number;
+    contentTonnes: Maybe<number>;
 };
 
 export type RawSubstanceConsumptionCalculated = {
@@ -58,10 +58,10 @@ export type RawSubstanceConsumptionCalculated = {
     data_status_autocalculated: number;
     health_sector_autocalculated: string;
     health_level_autocalculated: string;
-    kilograms_autocalculated: number;
-    packages_autocalculated: number;
+    kilograms_autocalculated: Maybe<number>;
+    packages_autocalculated: Maybe<number>;
     atc_version_autocalculated: ATCVersionKey;
-    ddds_autocalculated: number;
+    ddds_autocalculated: Maybe<number>;
     am_class: Maybe<AmName>;
     atc2: Maybe<string>;
     atc3: Maybe<string>;

--- a/src/domain/entities/data-entry/amc/RawSubstanceConsumptionData.ts
+++ b/src/domain/entities/data-entry/amc/RawSubstanceConsumptionData.ts
@@ -1,3 +1,4 @@
+import { Maybe } from "../../../../types/utils";
 import { ATCCodeLevel5, RouteOfAdministrationCode, SaltCode } from "../../GlassAtcVersionData";
 import { Id } from "../../Ref";
 
@@ -9,8 +10,8 @@ export type RawSubstanceConsumptionData = {
     packages_manual: number;
     ddds_manual: number;
     atc_version_manual: string;
-    tons_manual: number;
-    data_status_manual: number;
+    tons_manual: Maybe<number>;
+    data_status_manual: Maybe<number>;
     health_sector_manual: string;
     health_level_manual: string;
     report_date: string;

--- a/src/domain/entities/data-entry/amc/SubstanceConsumptionCalculated.ts
+++ b/src/domain/entities/data-entry/amc/SubstanceConsumptionCalculated.ts
@@ -13,11 +13,11 @@ export type SubstanceConsumptionCalculated = {
     atc_autocalculated: ATCCodeLevel5;
     route_admin_autocalculated: RouteOfAdministrationCode;
     salt_autocalculated: SaltCode;
-    packages_autocalculated: number;
-    ddds_autocalculated: number;
+    packages_autocalculated: Maybe<number>;
+    ddds_autocalculated: Maybe<number>;
     atc_version_autocalculated: ATCVersionKey;
-    kilograms_autocalculated: number;
-    data_status_autocalculated: number;
+    kilograms_autocalculated: Maybe<number>;
+    data_status_autocalculated: Maybe<number>;
     health_sector_autocalculated: string;
     health_level_autocalculated: string;
     am_class: Maybe<AmName>;

--- a/src/domain/usecases/data-entry/amc/utils/calculationConsumptionSubstanceLevelData.ts
+++ b/src/domain/usecases/data-entry/amc/utils/calculationConsumptionSubstanceLevelData.ts
@@ -150,7 +150,9 @@ export function calculateConsumptionSubstanceLevelData(
             const atcCodeByLevel = getAtcCodeByLevel(atcData, rawSubstanceConsumption.atc_manual);
             const aware = getAwareClass(awareClassData, rawSubstanceConsumption.atc_manual);
 
-            const rawSubstanceConsumptionKilograms = rawSubstanceConsumption.tons_manual * 1000;
+            const rawSubstanceConsumptionKilograms = rawSubstanceConsumption.tons_manual
+                ? rawSubstanceConsumption.tons_manual * 1000
+                : undefined;
             return {
                 period,
                 orgUnitId,


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #?

### :memo: Implementation
- Change domain entities according to mandatory data elements in programs
- Adapt calculations code to those changes

### :warning: METADATA CHANGES:
1. AMC - Product Register and in AMC - Product Register-APDV programs --> AMC - Raw Substance Consumption Calculated program stage:
	Compulsory data elements:
- AMR_GLASS_AMC_DET_ATC_AUTOCALCULATED
- AMR_GLASS_AMC_DET_ROUTE_ADMIN_AUTOCALCULATED	
- AMR_GLASS_AMC_DET_SALT_AUTOCALCULATED
- AMR_GLASS_AMC_DET_SECTOR_AUTOCALCULATED
- AMR_GLASS_AMC_DET_LEVEL_AUTOCALCULATED
- AMR_GLASS_AMC_DET_ATC_VERSION_AUTOCALCULATED
- AMR_GLASS_AMC_DET_DATA_STATUS_AUTOCALCULATED

2. AMC - Raw Substance Consumption Data program and AMC - Raw Substance Consumption Data-APDV program
	Compulsory data elements:
- AMR_GLASS_AMC_DET_ATC_MANUAL
- AMR_GLASS_AMC_DET_ROUTE_ADMIN_MANUAL
- AMR_GLASS_AMC_DET_SALT_MANUAL
- AMR_GLASS_AMC_DET_SECTOR_MANUAL
- AMR_GLASS_AMC_DET_LEVEL_MANUAL
- AMR_GLASS_AMC_DET_DDDS_MANUAL
- AMR_GLASS_AMC_DET_ATC_VERSION_MANUAL
- AMR_GLASS_AMC_DET_PACKAGES_MANUAL

### :video_camera: Screenshots/Screen capture
- Product level:
[AMC-PRODUCT-CALCULATED-CAN-Populated.xlsx](https://github.com/user-attachments/files/17747750/AMC-PRODUCT-CALCULATED-CAN-Populated.xlsx)
[AMC-SUBSTANCE-CALCULATED-CAN-Populated.xlsx](https://github.com/user-attachments/files/17747751/AMC-SUBSTANCE-CALCULATED-CAN-Populated.xlsx)

- Substance level:
[AMC-SUBSTANCE-CALCULATED-CAN-Populated (1).xlsx](https://github.com/user-attachments/files/17747747/AMC-SUBSTANCE-CALCULATED-CAN-Populated.1.xlsx)

### :fire: Testing
[AMC-Substance Level Data-CAN-TEMPLATE.xlsx](https://github.com/user-attachments/files/17747753/AMC-Substance.Level.Data-CAN-TEMPLATE.xlsx)
[AMC-Product Level Data-CAN-TEMPLATE.xlsx](https://github.com/user-attachments/files/17747754/AMC-Product.Level.Data-CAN-TEMPLATE.xlsx)
