### PR TITLE
set complete status before moving to step 4

### DIFF
--- a/src/webapp/components/upload/ReviewDataSummary.tsx
+++ b/src/webapp/components/upload/ReviewDataSummary.tsx
@@ -118,8 +118,6 @@ export const ReviewDataSummary: React.FC<ReviewDataSummaryProps> = ({
                             .run(
                                 () => {
                                     if (!secondaryUploadId) {
-                                        changeStep(4);
-                                        setIsLoading(false);
                                         //If Questionnaires are not applicable to a module, then set status as COMPLETE on
                                         //completion of dataset.
                                         if (
@@ -133,6 +131,8 @@ export const ReviewDataSummary: React.FC<ReviewDataSummaryProps> = ({
                                                 .setStatus(currentDataSubmissionId, "COMPLETE")
                                                 .run(
                                                     () => {
+                                                        changeStep(4);
+                                                        setIsLoading(false);
                                                         if (captureAccessGroup.kind === "loaded") {
                                                             const userGroupsIds = captureAccessGroup.data.map(cag => {
                                                                 return cag.id;
@@ -213,6 +213,8 @@ export const ReviewDataSummary: React.FC<ReviewDataSummaryProps> = ({
                                             .setStatus(currentDataSubmissionId, "COMPLETE")
                                             .run(
                                                 () => {
+                                                    changeStep(4);
+                                                    setIsLoading(false);
                                                     if (captureAccessGroup.kind === "loaded") {
                                                         const userGroupsIds = captureAccessGroup.data.map(cag => {
                                                             return cag.id;
@@ -233,15 +235,18 @@ export const ReviewDataSummary: React.FC<ReviewDataSummaryProps> = ({
                                                     }
                                                 },
                                                 error => {
+                                                    changeStep(4);
+                                                    setIsLoading(false);
                                                     console.debug(
                                                         "Error occurred when setting data submission status, error: " +
                                                             error
                                                     );
                                                 }
                                             );
+                                    } else {
+                                        changeStep(4);
+                                        setIsLoading(false);
                                     }
-                                    changeStep(4);
-                                    setIsLoading(false);
                                 },
                                 errorMessage => {
                                     snackbar.error(i18n.t(errorMessage));

--- a/src/webapp/components/upload/ReviewDataSummary.tsx
+++ b/src/webapp/components/upload/ReviewDataSummary.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from "react";
-import { Button, CircularProgress, Typography } from "@material-ui/core";
+import { Backdrop, Button, CircularProgress, Typography } from "@material-ui/core";
 import styled from "styled-components";
 import { glassColors } from "../../pages/app/themes/dhis2.theme";
 import i18n from "@eyeseetea/d2-ui-components/locales";
@@ -18,6 +18,7 @@ import { useGetLastSuccessfulAnalyticsRunTime } from "../../hooks/useGetLastSucc
 import { Validations } from "../current-data-submission/Validations";
 import { useQuestionnaires } from "../current-data-submission/Questionnaires";
 import { QuestionnaireBase } from "../../../domain/entities/Questionnaire";
+import { StyledLoaderContainer } from "./ConsistencyChecks";
 
 interface ReviewDataSummaryProps {
     changeStep: (step: number) => void;
@@ -52,7 +53,6 @@ export const ReviewDataSummary: React.FC<ReviewDataSummaryProps> = ({
     );
     const { captureAccessGroup } = useCurrentUserGroupsAccess();
     const [isReportReady, setIsReportReady] = useState<boolean>(false);
-    const [currentDataSubmissionId, setCurrentDataSubmissionId] = useState<string>("");
     const [currentQuestionnaires, setCurrentQuestionnaires] = useState<QuestionnaireBase[]>();
 
     const [questionnaires] = useQuestionnaires();
@@ -64,10 +64,6 @@ export const ReviewDataSummary: React.FC<ReviewDataSummaryProps> = ({
     const { lastSuccessfulAnalyticsRunTime, setRefetch } = useGetLastSuccessfulAnalyticsRunTime();
 
     useEffect(() => {
-        if (dataSubmissionId !== "" && currentDataSubmissionId === "") {
-            setCurrentDataSubmissionId(dataSubmissionId);
-        }
-
         if (questionnaires && !currentQuestionnaires) {
             setCurrentQuestionnaires(questionnaires);
         }
@@ -88,7 +84,6 @@ export const ReviewDataSummary: React.FC<ReviewDataSummaryProps> = ({
         lastSuccessfulAnalyticsRunTime,
         primaryFileImportSummary?.importTime,
         dataSubmissionId,
-        currentDataSubmissionId,
         currentQuestionnaires,
         questionnaires,
     ]);
@@ -128,7 +123,7 @@ export const ReviewDataSummary: React.FC<ReviewDataSummaryProps> = ({
                                                 currentQuestionnaires?.every(q => q.isMandatory && q.isCompleted))
                                         ) {
                                             compositionRoot.glassDataSubmission
-                                                .setStatus(currentDataSubmissionId, "COMPLETE")
+                                                .setStatus(dataSubmissionId, "COMPLETE")
                                                 .run(
                                                     () => {
                                                         changeStep(4);
@@ -153,12 +148,17 @@ export const ReviewDataSummary: React.FC<ReviewDataSummaryProps> = ({
                                                         }
                                                     },
                                                     error => {
-                                                        console.debug(
-                                                            "Error occurred when setting data submission status, error: " +
-                                                                error
+                                                        snackbar.error(
+                                                            i18n.t(
+                                                                "Error occurred when setting data submission status, error: " +
+                                                                    error
+                                                            )
                                                         );
                                                     }
                                                 );
+                                        } else {
+                                            changeStep(4);
+                                            setIsLoading(false);
                                         }
                                     } else {
                                         return compositionRoot.glassUploads
@@ -209,40 +209,38 @@ export const ReviewDataSummary: React.FC<ReviewDataSummaryProps> = ({
                                             "QUESTIONNAIRE_AND_DATASET" &&
                                             currentQuestionnaires?.every(q => q.isMandatory && q.isCompleted))
                                     ) {
-                                        compositionRoot.glassDataSubmission
-                                            .setStatus(currentDataSubmissionId, "COMPLETE")
-                                            .run(
-                                                () => {
-                                                    changeStep(4);
-                                                    setIsLoading(false);
-                                                    if (captureAccessGroup.kind === "loaded") {
-                                                        const userGroupsIds = captureAccessGroup.data.map(cag => {
-                                                            return cag.id;
-                                                        });
-                                                        const notificationText = `The data submission for ${currentModuleAccess.moduleName} module for year ${currentPeriod} and country ${currentOrgUnitAccess.orgUnitName} has changed to DATA TO BE APPROVED BY COUNTRY`;
+                                        compositionRoot.glassDataSubmission.setStatus(dataSubmissionId, "COMPLETE").run(
+                                            () => {
+                                                changeStep(4);
+                                                setIsLoading(false);
+                                                if (captureAccessGroup.kind === "loaded") {
+                                                    const userGroupsIds = captureAccessGroup.data.map(cag => {
+                                                        return cag.id;
+                                                    });
+                                                    const notificationText = `The data submission for ${currentModuleAccess.moduleName} module for year ${currentPeriod} and country ${currentOrgUnitAccess.orgUnitName} has changed to DATA TO BE APPROVED BY COUNTRY`;
 
-                                                        compositionRoot.notifications
-                                                            .send(
-                                                                notificationText,
-                                                                notificationText,
-                                                                userGroupsIds,
-                                                                currentOrgUnitAccess.orgUnitPath
-                                                            )
-                                                            .run(
-                                                                () => {},
-                                                                () => {}
-                                                            );
-                                                    }
-                                                },
-                                                error => {
-                                                    changeStep(4);
-                                                    setIsLoading(false);
-                                                    console.debug(
-                                                        "Error occurred when setting data submission status, error: " +
-                                                            error
-                                                    );
+                                                    compositionRoot.notifications
+                                                        .send(
+                                                            notificationText,
+                                                            notificationText,
+                                                            userGroupsIds,
+                                                            currentOrgUnitAccess.orgUnitPath
+                                                        )
+                                                        .run(
+                                                            () => {},
+                                                            () => {}
+                                                        );
                                                 }
-                                            );
+                                            },
+                                            error => {
+                                                changeStep(4);
+                                                setIsLoading(false);
+                                                console.debug(
+                                                    "Error occurred when setting data submission status, error: " +
+                                                        error
+                                                );
+                                            }
+                                        );
                                     } else {
                                         changeStep(4);
                                         setIsLoading(false);
@@ -264,25 +262,33 @@ export const ReviewDataSummary: React.FC<ReviewDataSummaryProps> = ({
             );
         }
     }, [
-        changeStep,
+        primaryFile,
+        secondaryFile,
         compositionRoot.glassUploads,
-        snackbar,
-        captureAccessGroup,
         compositionRoot.glassDataSubmission,
         compositionRoot.notifications,
         currentModuleAccess.moduleName,
-        currentOrgUnitAccess,
-        currentPeriod,
-        currentDataSubmissionId,
         currentQuestionnaires,
-        primaryFile,
-        secondaryFile,
+        dataSubmissionId,
+        changeStep,
+        captureAccessGroup,
+        currentPeriod,
+        currentOrgUnitAccess.orgUnitName,
+        currentOrgUnitAccess.orgUnitPath,
+        snackbar,
     ]);
 
     const goToFinalStepEffect = useCallbackEffect(goToFinalStep);
 
     return (
         <ContentWrapper>
+            <Backdrop open={isLoading || !dataSubmissionId} style={{ color: "#fff", zIndex: 1 }}>
+                <StyledLoaderContainer>
+                    <CircularProgress color="inherit" size={50} />
+                    <Typography variant="h6">{i18n.t("Loading")}</Typography>
+                </StyledLoaderContainer>
+            </Backdrop>
+
             {moduleProperties.get(currentModuleAccess.moduleName)?.isSecondaryFileApplicable &&
                 !moduleProperties.get(currentModuleAccess.moduleName)?.isSingleFileTypePerSubmission && (
                     <div className="toggles">
@@ -354,23 +360,19 @@ export const ReviewDataSummary: React.FC<ReviewDataSummaryProps> = ({
                 </SectionCard>
             </Section>
             <div className="bottom">
-                {isLoading ? (
-                    <CircularProgress size={25} />
-                ) : (
-                    <FlexWrapper>
-                        <Button
-                            variant="contained"
-                            color={"primary"}
-                            endIcon={<ChevronRightIcon />}
-                            onClick={goToFinalStepEffect}
-                            disableElevation
-                            disabled={isRunningCalculation}
-                        >
-                            {i18n.t("Continue")}
-                        </Button>
-                        {isRunningCalculation && <CircularProgress size={25} />}
-                    </FlexWrapper>
-                )}
+                <FlexWrapper>
+                    <Button
+                        variant="contained"
+                        color={"primary"}
+                        endIcon={<ChevronRightIcon />}
+                        onClick={goToFinalStepEffect}
+                        disableElevation
+                        disabled={isRunningCalculation}
+                    >
+                        {i18n.t("Continue")}
+                    </Button>
+                    {isRunningCalculation && <CircularProgress size={25} />}
+                </FlexWrapper>
             </div>
         </ContentWrapper>
     );

--- a/src/webapp/hooks/useCurrentDataSubmissionId.ts
+++ b/src/webapp/hooks/useCurrentDataSubmissionId.ts
@@ -1,19 +1,24 @@
 import { useEffect, useState } from "react";
 import { useAppContext } from "../contexts/app-context";
+import { useSnackbar } from "@eyeseetea/d2-ui-components";
 
 export function useCurrentDataSubmissionId(moduleId: string, moduleName: string, orgUnit: string, period: string) {
     const { currentUser, compositionRoot } = useAppContext();
     const [currentDataSubmissionId, setCurrentDataSubmissionId] = useState<string>("");
+    const snackbar = useSnackbar();
 
     useEffect(() => {
-        async function getDataSubmission() {
-            const isQuarterlyModule = currentUser.quarterlyPeriodModules.find(m => m.id === moduleId) ? true : false;
-            const currentDataSubmission = await compositionRoot.glassDataSubmission
-                .getSpecificDataSubmission(moduleId, moduleName, orgUnit, period, isQuarterlyModule)
-                .toPromise();
-            setCurrentDataSubmissionId(currentDataSubmission.id);
-        }
-        getDataSubmission();
+        const isQuarterlyModule = currentUser.quarterlyPeriodModules.find(m => m.id === moduleId) ? true : false;
+        compositionRoot.glassDataSubmission
+            .getSpecificDataSubmission(moduleId, moduleName, orgUnit, period, isQuarterlyModule)
+            .run(
+                currentDataSubmission => {
+                    setCurrentDataSubmissionId(currentDataSubmission.id);
+                },
+                error => {
+                    snackbar.error("Error fetching data submission : " + error);
+                }
+            );
     }, [
         compositionRoot.glassDataSubmission,
         moduleId,
@@ -21,6 +26,7 @@ export function useCurrentDataSubmissionId(moduleId: string, moduleName: string,
         orgUnit,
         period,
         currentUser.quarterlyPeriodModules,
+        snackbar,
     ]);
 
     return currentDataSubmissionId;


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #? https://app.clickup.com/t/8697c0fnf, #8697c0fnf

### :memo: Implementation
1. Wait for  get specific data submission to be fetched before loading page.
2. The get specific data submission hook was using promises, refactored to use futures.
3. Change from step 3 (Review data summary) to step 4 (completion screen) only after updating the data submission status to "COMPLETE" (Data to be approved by country)


### :video_camera: Screenshots/Screen capture

https://github.com/user-attachments/assets/239c1341-5fa1-4338-a83f-4d888516e3f5



### :fire: Testing
.
