### PR TITLE
Add css to render the questionnaire description and position it below questionnaire + remove it from questionnaire card

### DIFF
--- a/src/webapp/components/current-data-submission/Questionnaires.tsx
+++ b/src/webapp/components/current-data-submission/Questionnaires.tsx
@@ -204,7 +204,6 @@ export const Questionnaires: React.FC<QuestionnairesProps> = ({ setRefetchStatus
                     <QuestionnaireCard key={`${questionnaire.id}${questionnaire.name}`}>
                         <div className="head">
                             <h3 style={{ wordBreak: "break-all" }}>{questionnaire.name}</h3>
-                            <span className="desc">{questionnaire.description}</span>
                             <br />
                             {questionnaire.subQuestionnaires && questionnaire.subQuestionnaires.length > 0 && (
                                 <>

--- a/src/webapp/components/questionnaire/QuestionnaireActions.tsx
+++ b/src/webapp/components/questionnaire/QuestionnaireActions.tsx
@@ -20,7 +20,7 @@ interface QuestionnaireHeaderProps {
 }
 
 export const QuestionnaireActions: React.FC<QuestionnaireHeaderProps> = props => {
-    const { description, isCompleted, isSaving, mode, saveQuestionnaireActions, setAsCompleted } = props;
+    const { isCompleted, isSaving, mode, saveQuestionnaireActions, setAsCompleted } = props;
     const { saveQuestionnaire, disableSave, isSavingQuestionnaire } = saveQuestionnaireActions;
     const hasCurrentUserCaptureAccess = useGlassCaptureAccess();
 

--- a/src/webapp/components/questionnaire/QuestionnaireActions.tsx
+++ b/src/webapp/components/questionnaire/QuestionnaireActions.tsx
@@ -62,9 +62,6 @@ export const QuestionnaireActions: React.FC<QuestionnaireHeaderProps> = props =>
                 </div>
             )}
 
-            <div className="head">
-                <span className="desc">{description}</span>
-            </div>
         </QuestionnaireHeaderStyled>
     );
 };

--- a/src/webapp/components/questionnaire/QuestionnaireActions.tsx
+++ b/src/webapp/components/questionnaire/QuestionnaireActions.tsx
@@ -78,6 +78,7 @@ const QuestionnaireHeaderStyled = styled.div`
 
     .desc {
         margin-left: 14px;
+        white-space: pre-wrap;
     }
 
     .comp {

--- a/src/webapp/components/questionnaire/QuestionnaireForm.tsx
+++ b/src/webapp/components/questionnaire/QuestionnaireForm.tsx
@@ -119,13 +119,14 @@ const QuestionnaireForm: React.FC<QuestionnarieFormProps> = props => {
                                 ))}
                             </TableBody>
                         </DataTable>
-                        <div className="desc-display">
-                            <span className="desc">{questionnaire.description}</span>
-                        </div>
                     </div>
                 );
             })}
+                        <div className="desc-display">
+                            <span className="desc">{questionnaire.description}</span>
+                        </div>
         </FormWrapper>
+        
     );
 };
 
@@ -133,12 +134,12 @@ const FormWrapper = styled.div`
     gap: 0px;
 
     .desc {
-            margin-left: 14px;
-            white-space: pre-wrap;
+         margin-left: 14px;
+         white-space: pre-wrap;
         }
         
     .desc-display * {
-        display: block;
+     display: block;
     }
         
 `;

--- a/src/webapp/components/questionnaire/QuestionnaireForm.tsx
+++ b/src/webapp/components/questionnaire/QuestionnaireForm.tsx
@@ -134,14 +134,13 @@ const FormWrapper = styled.div`
     gap: 0px;
 
     .desc {
-         margin-left: 14px;
-         white-space: pre-wrap;
-        }
-        
-    .desc-display * {
-     display: block;
+        margin-left: 14px;
+        white-space: pre-wrap;
     }
-        
+
+    .desc-display * {
+        display: block;
+    }
 `;
 
 function useSaveQuestionnaire(questionnaire: QuestionnaireSelector) {

--- a/src/webapp/components/questionnaire/QuestionnaireForm.tsx
+++ b/src/webapp/components/questionnaire/QuestionnaireForm.tsx
@@ -119,6 +119,9 @@ const QuestionnaireForm: React.FC<QuestionnarieFormProps> = props => {
                                 ))}
                             </TableBody>
                         </DataTable>
+                        <div className="desc-display">
+                            <span className="desc">{questionnaire.description}</span>
+                        </div>
                     </div>
                 );
             })}
@@ -128,6 +131,16 @@ const QuestionnaireForm: React.FC<QuestionnarieFormProps> = props => {
 
 const FormWrapper = styled.div`
     gap: 0px;
+
+    .desc {
+            margin-left: 14px;
+            white-space: pre-wrap;
+        }
+        
+    .desc-display * {
+        display: block;
+    }
+        
 `;
 
 function useSaveQuestionnaire(questionnaire: QuestionnaireSelector) {


### PR DESCRIPTION
I need to fix the rendering and position of the Questionnaire description as a quick fix to be able to have fixed text appear for the users in the Questionnaires to indicate notes of usage for the user. I hope to replace this with a better fix soon.