### PR TITLE
Reports not showing since DHIS2 upgrade

### DIFF
--- a/src/webapp/components/reports/EmbeddedReport.tsx
+++ b/src/webapp/components/reports/EmbeddedReport.tsx
@@ -58,7 +58,7 @@ export const EmbeddedReport: React.FC<EmbeddedReportProps> = ({ dashboardId }) =
 };
 
 const styles = {
-    iframe: { width: "100%", border: 0, overflow: "hidden" },
+    iframe: { width: "100%", border: 0, overflow: "hidden", height: "80vh" },
     wrapperVisible: { width: "100%" },
     wrapperHidden: { visibility: "hidden", width: "100%" },
 };


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #8698ybqy7 [Reports not showing since DHIS2 upgrade](https://app.clickup.com/t/8698ybqy7)

### :memo: Implementation
- Add height in iframe for dashboard version 2.41

### :video_camera: Screenshots/Screen capture

[Screencast from 2025-05-05 11-10-48.webm](https://github.com/user-attachments/assets/04168da7-1480-48b9-bf01-e366cd3b391f)

### :fire: Testing
