### PR TITLE
AMR-I: Add consistency checks for specimen/pathogen/antibiotic

### DIFF
--- a/src/domain/usecases/data-entry/ImportPrimaryFileUseCase.tsx
+++ b/src/domain/usecases/data-entry/ImportPrimaryFileUseCase.tsx
@@ -101,7 +101,8 @@ export class ImportPrimaryFileUseCase {
                     this.glassDocumentsRepository,
                     this.glassUploadsRepository,
                     this.metadataRepository,
-                    this.programRulesMetadataRepository
+                    this.programRulesMetadataRepository,
+                    this.glassModuleRepository
                 );
                 return this.glassModuleRepository.getByName(moduleName).flatMap(module => {
                     return importRISIndividualFungalFile.importRISIndividualFungalFile(

--- a/src/domain/usecases/data-entry/amr-individual-fungal/ImportRISIndividualFungalFile.ts
+++ b/src/domain/usecases/data-entry/amr-individual-fungal/ImportRISIndividualFungalFile.ts
@@ -7,11 +7,13 @@ import { TrackerRepository } from "../../../repositories/TrackerRepository";
 import { RISIndividualFungalDataRepository } from "../../../repositories/data-entry/RISIndividualFungalDataRepository";
 import { mapToImportSummary, uploadIdListFileAndSave } from "../ImportBLTemplateEventProgram";
 import { MetadataRepository } from "../../../repositories/MetadataRepository";
+import { GlassModuleRepository } from "../../../repositories/GlassModuleRepository";
 import { CustomDataColumns } from "../../../entities/data-entry/amr-individual-fungal-external/RISIndividualFungalData";
 import { ProgramRulesMetadataRepository } from "../../../repositories/program-rules/ProgramRulesMetadataRepository";
 import { downloadIdsAndDeleteTrackedEntities } from "../utils/downloadIdsAndDeleteTrackedEntities";
 import { Country } from "../../../entities/Country";
 import { mapIndividualFungalDataItemsToEntities, runCustomValidations, runProgramRuleValidations } from "./common";
+import { checkSpecimenPathogenFromDataColumns } from "../utils/checkSpecimenPathogen";
 
 export const AMRIProgramID = "mMAj6Gofe49";
 export const AMR_GLASS_AMR_TET_PATIENT = "CcgnfemKr5U";
@@ -25,7 +27,8 @@ export class ImportRISIndividualFungalFile {
         private glassDocumentsRepository: GlassDocumentsRepository,
         private glassUploadsRepository: GlassUploadsRepository,
         private metadataRepository: MetadataRepository,
-        private programRulesMetadataRepository: ProgramRulesMetadataRepository
+        private programRulesMetadataRepository: ProgramRulesMetadataRepository,
+        private moduleRepository: GlassModuleRepository
     ) {}
 
     public importRISIndividualFungalFile(
@@ -49,6 +52,33 @@ export class ImportRISIndividualFungalFile {
             return this.risIndividualFungalRepository
                 .get(dataColumns, inputFile)
                 .flatMap(risIndividualFungalDataItems => {
+                    return Future.joinObj({
+                        risIndividualFungalDataItems: Future.success(risIndividualFungalDataItems),
+                        module: this.moduleRepository.getByName(moduleName),
+                    });
+                })
+                .flatMap(({ risIndividualFungalDataItems, module }) => {
+                    const specimenPathogenAntibioticErrors = module.consistencyChecks
+                        ? checkSpecimenPathogenFromDataColumns(
+                              risIndividualFungalDataItems,
+                              module.consistencyChecks.specimenPathogen
+                          )
+                        : [];
+                    if (specimenPathogenAntibioticErrors.length > 0) {
+                        const errorSummary: ImportSummary = {
+                            status: "ERROR",
+                            importCount: {
+                                ignored: 0,
+                                imported: 0,
+                                deleted: 0,
+                                updated: 0,
+                                total: 0,
+                            },
+                            nonBlockingErrors: [],
+                            blockingErrors: specimenPathogenAntibioticErrors,
+                        };
+                        return Future.success(errorSummary);
+                    }
                     return runCustomValidations(risIndividualFungalDataItems, countryCode, period).flatMap(
                         validationSummary => {
                             //If there are blocking errors on custom validation, do not import. Return immediately.


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8698yjt72 #8698yjt72

### :memo: Implementation

Replicated to AMR-I the same specimen/pathogen/antibiotic validation applied in the AMR-Aggregated.

**NOTE**: The validation is based on dataStore configuration, so it **requires changes to the dataStore**: 

In the `/glass/modules` key, look in the array for the object with name `AMR - individual`. In that object, add the `consistencyChecks` property, with the contents cloned from the same `consistencyChecks` from the `AMR` module.
I'm including a full JSON backup in the linked issue.

### :video_camera: Screenshots/Screen capture

![imagen](https://github.com/user-attachments/assets/3f2ce182-2426-4d1f-80bf-f03e5345a3f9)

### :fire: Testing
