### PR TITLE
fix: AMR save questionnaire 409 error

### DIFF
--- a/src/data/repositories/QuestionnaireD2DefaultRepository.ts
+++ b/src/data/repositories/QuestionnaireD2DefaultRepository.ts
@@ -308,18 +308,23 @@ export class QuestionnaireD2DefaultRepository implements QuestionnaireRepository
                     const isSelected = question.value?.id === option.id;
                     return {
                         ...base,
-                        value: isSelected ? "true" : "",
+                        // value: isSelected ? "true" : "",
+                        // passing value: "" for YES_ONLY dataElements will cause 409 errors in dhis2 > 2.39 because of an unhandled NullPointerException
+                        // we pass "true" as a dummy value to circumvent this and use the deleted flag
+                        value: "true",
                         categoryOptionCombo: option.id,
                         ...deleted(!isSelected),
                     };
                 });
             case "boolean": {
-                const strValue = question.value ? "true" : question.storeFalse ? "false" : "";
+                // value: "" for YES_ONLY dataElements will cause 409 errors in dhis2 > 2.39 because of an unhandled NullPointerException
+                // we pass "true" as a dummy value to circumvent this and use the deleted flag
+                const strValue = question.value ? "true" : question.storeFalse ? "false" : "true";
                 return [
                     {
                         ...base,
                         value: strValue,
-                        ...deleted(!strValue),
+                        ...deleted(!question.value && !question.storeFalse),
                     },
                 ];
             }
@@ -341,12 +346,14 @@ export class QuestionnaireD2DefaultRepository implements QuestionnaireRepository
                     },
                 ];
             case "singleCheck": {
-                const strValue = question.value ? "true" : question.storeFalse ? "false" : "";
+                // value: "" for YES_ONLY dataElements will cause 409 errors in dhis2 > 2.39 because of an unhandled NullPointerException
+                // we pass "true" as a dummy value to circumvent this and use the deleted flag
+                const strValue = question.value ? "true" : question.storeFalse ? "false" : "true";
                 return [
                     {
                         ...base,
                         value: strValue,
-                        ...deleted(!strValue),
+                        ...deleted(!question.value && !question.storeFalse),
                     },
                 ];
             }


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869959024 #869959024

### :memo: Implementation

- Sending `""` as the value in the `dataValues` APIs for YES_ONLY dataElements causes an unhandled NullPointerException in the API, which is returned as a 409 conflict error. Confirmed this behavior started on dhis >= v2.40.
- As a workaround, send a dummy `"true"` value when posting the dataValues, even if we want to clear them out. The dataValues will be deleted because at the same time we are using the `deleted` flag.
- Observed that the new DataEntry app (beta) will send an empty value and it works, but only because it uses content-type multipart/form-data. Older dataentry app won't work when unchecking a yes_only dataValue - same error as in glass.

### :video_camera: Screenshots/Screen capture

### :fire: Testing
