### PR TITLE
fix: checkPeriod validation for timezones with negative GMT offsets

### DIFF
--- a/src/domain/usecases/data-entry/amc/CustomValidationsAMCProductData.ts
+++ b/src/domain/usecases/data-entry/amc/CustomValidationsAMCProductData.ts
@@ -139,7 +139,7 @@ export class CustomValidationsAMCProductData {
                         line: tei.trackedEntity ? parseInt(tei.trackedEntity) + 6 : -1,
                     });
                 }
-                if (eventDate.getFullYear().toString() !== period) {
+                if (eventDate.getUTCFullYear().toString() !== period) {
                     curErrors.push({
                         error: i18n.t(
                             `Event date is incorrect: Selected period : ${period}, date in file: ${

--- a/src/domain/usecases/data-entry/egasp/CustomValidationForEventProgram.ts
+++ b/src/domain/usecases/data-entry/egasp/CustomValidationForEventProgram.ts
@@ -148,7 +148,7 @@ export class CustomValidationForEventProgram {
         const errors = _(
             events.map(event => {
                 const eventDate = new Date(event.occurredAt);
-                if (eventDate.getFullYear().toString() !== period) {
+                if (eventDate.getUTCFullYear().toString() !== period) {
                     return {
                         error: i18n.t(
                             `Event date is incorrect: Selected period : ${period}, date in file: ${event.occurredAt}`


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** May be related to: 
  - https://app.clickup.com/t/8699apv1h
  - https://app.clickup.com/t/8699apxx8

### :memo: Implementation

- Period validation was failing for negative GMT offset timezones. i.e. GMT-3. 
  - When uploading a document that contains a row for 2024 and the selected period is 2024, the upload was failing, with blocking validation errors regarding period (unexpected)
  - When uploading a document that contains a row for 2025 and the selected period is 2024, the upload would work, no validation errors (unexpected)
    - This specific case, of rows with a date outside the period, may lead to problem with rows not being removed and duplicates later in the flow, when approving/requesting changes/deleting/submitting/approving.

- For example, if `eventDate` === `new Date('2024-01-01')`
  - `(new Date('2024-01-01')).getFullYear() === 2023`
  - `(new Date('2024-01-01')).getUTCFullYear() === 2024`

### :video_camera: Screenshots/Screen capture

### :fire: Testing

- You can reproduce the issue by changing the timezone in your OS settings to one that has a negative GMT offset.