### PR TITLE
fix: handle AMC Questionnaire loading errors

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2025-06-03T16:56:09.366Z\n"
-"PO-Revision-Date: 2025-06-03T16:56:09.366Z\n"
+"POT-Creation-Date: 2025-06-13T15:23:00.897Z\n"
+"PO-Revision-Date: 2025-06-13T15:23:00.897Z\n"
 
 msgid "Template {{id}} not loaded"
 msgstr ""
@@ -440,6 +440,17 @@ msgid "Error downloading data"
 msgstr ""
 
 msgid "Back"
+msgstr ""
+
+msgid "Error loading AMC Questionnaire"
+msgstr ""
+
+msgid "This may be due to a network issue or a data inconsistency. "
+msgstr ""
+
+msgid ""
+"Please check the error details below, correct any issues with the event, "
+"and try again. If the problem persists, contact support for assistance."
 msgstr ""
 
 msgid "Edit"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2025-06-03T16:56:09.366Z\n"
+"POT-Creation-Date: 2025-06-13T15:23:00.897Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -443,6 +443,17 @@ msgstr ""
 
 msgid "Back"
 msgstr "Volver"
+
+msgid "Error loading AMC Questionnaire"
+msgstr ""
+
+msgid "This may be due to a network issue or a data inconsistency. "
+msgstr ""
+
+msgid ""
+"Please check the error details below, correct any issues with the event, and "
+"try again. If the problem persists, contact support for assistance."
+msgstr ""
 
 msgid "Edit"
 msgstr ""

--- a/src/data/repositories/amc-questionnaires/AMCQuestionnaireD2Repository.ts
+++ b/src/data/repositories/amc-questionnaires/AMCQuestionnaireD2Repository.ts
@@ -183,30 +183,55 @@ export class AMCQuestionnaireD2Repository implements AMCQuestionnaireRepository 
                         generalAMCQuestionnaire.id,
                         orgUnitId
                     ),
-                }).map(({ amClassAMCQuestionnaires, componentAMCQuestionnaires }) => {
-                    return new AMCQuestionnaire({
-                        id: generalAMCQuestionnaire.id,
-                        orgUnitId: orgUnitId,
-                        period: period,
-                        generalQuestionnaire: generalAMCQuestionnaire,
-                        amClassQuestionnaires: amClassAMCQuestionnaires,
-                        componentQuestionnaires: componentAMCQuestionnaires,
-                    });
+                }).flatMap(({ amClassAMCQuestionnaires, componentAMCQuestionnaires }) => {
+                    try {
+                        const questionnaire = new AMCQuestionnaire({
+                            id: generalAMCQuestionnaire.id,
+                            orgUnitId: orgUnitId,
+                            period: period,
+                            generalQuestionnaire: generalAMCQuestionnaire,
+                            amClassQuestionnaires: amClassAMCQuestionnaires,
+                            componentQuestionnaires: componentAMCQuestionnaires,
+                        });
+                        return Future.success(questionnaire);
+                    } catch (error) {
+                        return Future.error(error instanceof Error ? error.message : String(error));
+                    }
                 });
             }
         );
     }
 
     private getAmClassQuestionnairesInAggregateRoot(id: Id, orgUnitId: Id): FutureData<AMClassAMCQuestionnaire[]> {
-        return this.getEventsFromSection(id, orgUnitId, AMR_GLASS_AMC_AM_CLASS_QUESTIONNAIRE_STAGE_ID).map(events => {
-            return events.map(event => mapD2EventToAMClassAMCQuestionnaire(event));
-        });
+        return this.getEventsFromSection(id, orgUnitId, AMR_GLASS_AMC_AM_CLASS_QUESTIONNAIRE_STAGE_ID).flatMap(
+            events => {
+                try {
+                    const mapped = events.map(event => mapD2EventToAMClassAMCQuestionnaire(event));
+                    return Future.success(mapped);
+                } catch (error) {
+                    return Future.error(
+                        `Error in AM Class AMC Questionnaires: ${
+                            error instanceof Error ? error.message : String(error)
+                        }`
+                    );
+                }
+            }
+        );
     }
 
     private getComponentQuestionnairesInAggregateRoot(id: Id, orgUnitId: Id): FutureData<ComponentAMCQuestionnaire[]> {
-        return this.getEventsFromSection(id, orgUnitId, AMR_GLASS_AMC_AM_COMPONENT_QUESTIONNAIRE_STAGE_ID).map(
+        return this.getEventsFromSection(id, orgUnitId, AMR_GLASS_AMC_AM_COMPONENT_QUESTIONNAIRE_STAGE_ID).flatMap(
             events => {
-                return events.map(event => mapD2EventToComponentAMCQuestionnaire(event));
+                try {
+                    const mapped = events.map(event => mapD2EventToComponentAMCQuestionnaire(event));
+                    return Future.success(mapped);
+                } catch (error) {
+                    return Future.error(
+                        `Error in Component AMC Questionnaires: ${
+                            error instanceof Error ? error.message : String(error)
+                        }`
+                    );
+                }
             }
         );
     }

--- a/src/domain/entities/amc-questionnaires/AMCQuestionnaire.ts
+++ b/src/domain/entities/amc-questionnaires/AMCQuestionnaire.ts
@@ -33,6 +33,14 @@ const amClassOptionToGeneralMap: Record<AntimicrobialClassValue, keyof GeneralAM
 } as const;
 
 export class AMCQuestionnaire extends Struct<AMCQuestionnaireAttrs>() {
+    constructor(_attributes: AMCQuestionnaireAttrs) {
+        super(_attributes);
+        const validationResults = this.validate();
+        if (validationResults.length > 0) {
+            throw new Error(`Invalid AMCQuestionnaire: ${validationResults.join(", ")}`);
+        }
+    }
+
     public validate(): ValidationErrorKey[] {
         const validationErrors: ValidationErrorKey[] = [];
         if (!this.validateAMClassQuestionnairesHasOptionChecked()) {

--- a/src/webapp/components/current-data-submission/amc-questionnaires/MainPageAMCQuestionnaires.tsx
+++ b/src/webapp/components/current-data-submission/amc-questionnaires/MainPageAMCQuestionnaires.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import styled from "styled-components";
-import { Button, CircularProgress } from "@material-ui/core";
+import { Button, CircularProgress, Typography } from "@material-ui/core";
 
 import { AMCQuestionnaireFormPage } from "./AMCQuestionnaireFormPage";
 import { useCurrentPeriodContext } from "../../../contexts/current-period-context";
@@ -11,6 +11,7 @@ import { QuestionnairesTable } from "../../questionnaires-table/QuestionnairesTa
 import { Id } from "../../../../domain/entities/Ref";
 import { AMCQuestionnairePage } from "./AMCQuestionnairePage";
 import { MissingComponentQuestionnaires } from "./MissingComponentQuestionnaires";
+import { palette } from "../../../pages/app/themes/dhis2.theme";
 
 export const MainPageAMCQuestionnaires: React.FC = () => {
     const { currentPeriod } = useCurrentPeriodContext();
@@ -27,6 +28,7 @@ export const MainPageAMCQuestionnaires: React.FC = () => {
         onSaveForm,
         openQuestionnaireForm,
         onCloseQuestionnaireForm,
+        questionnaireError,
     } = useMainPageAMCQuestionnaire();
 
     return (
@@ -45,6 +47,21 @@ export const MainPageAMCQuestionnaires: React.FC = () => {
                         <LoaderContainer>
                             <CircularProgress />
                         </LoaderContainer>
+                    ) : questionnaireError ? (
+                        <ErrorContainer>
+                            <Typography variant="h6">{i18n.t("Error loading AMC Questionnaire")}</Typography>
+                            <Typography variant="body1">
+                                {i18n.t("This may be due to a network issue or a data inconsistency. ")}
+                            </Typography>
+                            <Typography variant="body1">
+                                {i18n.t(
+                                    "Please check the error details below, correct any issues with the event, and try again. If the problem persists, contact support for assistance."
+                                )}
+                            </Typography>
+                            <Typography variant="caption" style={{ marginTop: "1em" }} paragraph>
+                                {questionnaireError.message}
+                            </Typography>
+                        </ErrorContainer>
                     ) : (
                         <QuestionnairesContainer>
                             <ButtonsContainer>
@@ -119,6 +136,12 @@ const ButtonsContainer = styled.div`
 const QuestionnairesContainer = styled.div``;
 
 const LoaderContainer = styled.div``;
+
+const ErrorContainer = styled.div`
+    border: 1px solid ${palette.error.main};
+    color: ${palette.error.main};
+    padding: 2em;
+`;
 
 const GeneralQuestionnaireContainer = styled.div`
     border: 1px solid #ccc;

--- a/src/webapp/components/current-data-submission/amc-questionnaires/useMainPageAMCQuestionnaire.ts
+++ b/src/webapp/components/current-data-submission/amc-questionnaires/useMainPageAMCQuestionnaire.ts
@@ -29,10 +29,11 @@ type MainPageAMCQuestionnaireState = {
     onSaveForm: () => void;
     onCloseQuestionnaireForm: () => void;
     openQuestionnaireForm: (formType: AMCQuestionnaireFormType, id?: Id) => void;
+    questionnaireError: Maybe<Error>;
 };
 
 export function useMainPageAMCQuestionnaire(): MainPageAMCQuestionnaireState {
-    const { questionnaire, questionnaireIsLoading } = useAMCQuestionnaireContext();
+    const { questionnaire, questionnaireIsLoading, questionnaireError } = useAMCQuestionnaireContext();
     const formOptions = useAMCQuestionnaireOptionsContext();
 
     const [isEditMode, setIsEditMode] = useState(false);
@@ -97,5 +98,6 @@ export function useMainPageAMCQuestionnaire(): MainPageAMCQuestionnaireState {
         onSaveForm: onCancelEditMode,
         onCloseQuestionnaireForm,
         openQuestionnaireForm,
+        questionnaireError,
     };
 }

--- a/src/webapp/context-providers/AMCQuestionnaireContextProvider.tsx
+++ b/src/webapp/context-providers/AMCQuestionnaireContextProvider.tsx
@@ -23,6 +23,7 @@ export const AMCQuestionnaireContextProvider: React.FC = ({ children }) => {
 
     const fetchQuestionnaire = useCallback(() => {
         setAMCQuestionnaireIsLoading(true);
+        setAMCQuestionnaireError(undefined);
         return Future.joinObj({
             amcQuestionnaireResponse: compositionRoot.amcQuestionnaires.getByOrgUnitAndPeriod(
                 currentOrgUnitAccess.orgUnitId,
@@ -42,6 +43,10 @@ export const AMCQuestionnaireContextProvider: React.FC = ({ children }) => {
                 setAMCQuestionnaireIsLoading(false);
                 if (error instanceof Error) {
                     setAMCQuestionnaireError(error);
+                } else if (typeof error === "string") {
+                    setAMCQuestionnaireError(new Error(error));
+                } else {
+                    setAMCQuestionnaireError(new Error("Unknown error occurred while fetching the AMC Questionnaire"));
                 }
             }
         );


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Related https://app.clickup.com/t/869900zzw

### :memo: Implementation

- Add error handling when loading Questionnaire forms
  - Handle errors in mappings from Events to Domain entities (if some fields are missing or incomplete in the Event)
  - Validate business rules and throw error when creating an `AMCQuestionnaire`
- Show an error message with details

This was previously unhandled, now a message is displayed. This is useful for having more details into what and why the error is happening. Now it may be due to trying to view Questionnaires created before schema changes around Stratum (should only happen in dev). In the future it might be useful if bad data is created through bulk-upload. 

The next step, if needed, would be to let the user fix the errors within the app, but it would require more work since all the business entities are only representing valid states.

### :video_camera: Screenshots/Screen capture

![imagen](https://github.com/user-attachments/assets/775e1e66-316f-4ac2-85bd-63df1342ced8)


### :fire: Testing
