### PR TITLE
fix: change yes/no options to radio buttons

### DIFF
--- a/src/webapp/components/current-data-submission/amc-questionnaires/getComponentAMCQuestionnaireFormEntity.ts
+++ b/src/webapp/components/current-data-submission/amc-questionnaires/getComponentAMCQuestionnaireFormEntity.ts
@@ -2,6 +2,7 @@ import { AMCQuestionnaireQuestions } from "../../../../domain/entities/amc-quest
 import { ComponentAMCQuestionnaire } from "../../../../domain/entities/amc-questionnaires/ComponentAMCQuestionnaire";
 import { DataLevelValues } from "../../../../domain/entities/amc-questionnaires/DataLevelOption";
 import { NationalPopulationDataSourceValues } from "../../../../domain/entities/amc-questionnaires/NationalPopulationDataSourceOption";
+import { YesNoValues } from "../../../../domain/entities/amc-questionnaires/YesNoOption";
 import { YesNoUnknownValues } from "../../../../domain/entities/amc-questionnaires/YesNoUnknownOption";
 import { Maybe } from "../../../../utils/ts-utils";
 import { FormMultipleOptionsFieldState } from "../../form/presentation-entities/FormFieldsState";
@@ -84,7 +85,7 @@ function getComponentAMCQuestionnaireFormLabelsRules(): { rules: FormRule[]; lab
             {
                 type: "requiredFieldsByFieldValue",
                 fieldId: "sameAsUNPopulation",
-                fieldValue: false, // checkboxes return booleans instead of YesNoValue
+                fieldValue: YesNoValues.NO,
                 requiredFieldIds: ["sourceOfNationalPopulation"],
                 sectionIdsWithRequiredFields: ["component_section"],
             },

--- a/src/webapp/components/current-data-submission/amc-questionnaires/mappers/amClassAMCQuestionnaireMapper.ts
+++ b/src/webapp/components/current-data-submission/amc-questionnaires/mappers/amClassAMCQuestionnaireMapper.ts
@@ -3,12 +3,11 @@ import {
     getAllFieldsFromSections,
     getFieldIdFromIdsDictionary,
     getMultipleOptionsFieldValue,
-    getStringFieldValue,
 } from "../../../form/presentation-entities/FormFieldsState";
 import { FormState } from "../../../form/presentation-entities/FormState";
 import { AMClassAMCQuestionnaireFormEntity } from "../presentation-entities/QuestionnaireFormEntity";
 import { MapToAMCQuestionnaireParams, MapToFormStateParams } from "./mapperTypes";
-import { getQuestionById, mapToFormOptions } from "./mapperUtils";
+import { getOptionCodeFromFieldValue, getQuestionById, mapToFormOptions } from "./mapperUtils";
 import {
     AMClassAMCQuestionId,
     AMClassAMCQuestionnaire,
@@ -23,23 +22,31 @@ export function mapFormStateToAMClassAMCQuestionnaire(
 
     const allFields: FormFieldState[] = getAllFieldsFromSections(formState.sections);
 
-    const antimicrobialClass = options.antimicrobialClassOptions.find(
-        option => option.code === getStringFieldValue("antimicrobialClass", allFields)
-    )?.code;
+    const antimicrobialClass = getOptionCodeFromFieldValue(
+        "antimicrobialClass",
+        options.antimicrobialClassOptions,
+        allFields
+    );
     const stratas = _.compact(
         getMultipleOptionsFieldValue("stratas", allFields).map(selectedOption => {
             return options.strataOptions.find(option => option.code === selectedOption)?.code;
         })
     );
-    const estVolumeTotalHealthLevel = options.proportion50to100Options.find(
-        option => option.code === getStringFieldValue("estVolumeTotalHealthLevel", allFields)
-    )?.code;
-    const estVolumeHospitalHealthLevel = options.proportion50to100Options.find(
-        option => option.code === getStringFieldValue("estVolumeHospitalHealthLevel", allFields)
-    )?.code;
-    const estVolumeCommunityHealthLevel = options.proportion50to100Options.find(
-        option => option.code === getStringFieldValue("estVolumeCommunityHealthLevel", allFields)
-    )?.code;
+    const estVolumeTotalHealthLevel = getOptionCodeFromFieldValue(
+        "estVolumeTotalHealthLevel",
+        options.proportion50to100Options,
+        allFields
+    );
+    const estVolumeHospitalHealthLevel = getOptionCodeFromFieldValue(
+        "estVolumeHospitalHealthLevel",
+        options.proportion50to100Options,
+        allFields
+    );
+    const estVolumeCommunityHealthLevel = getOptionCodeFromFieldValue(
+        "estVolumeCommunityHealthLevel",
+        options.proportion50to100Options,
+        allFields
+    );
 
     if (!antimicrobialClass || !stratas) {
         throw new Error("Missing required AM Class AMC Questionnaire attributes");

--- a/src/webapp/components/current-data-submission/amc-questionnaires/mappers/componentAMCQuestionnaireMapper.ts
+++ b/src/webapp/components/current-data-submission/amc-questionnaires/mappers/componentAMCQuestionnaireMapper.ts
@@ -2,7 +2,6 @@ import _ from "lodash";
 import {
     FormFieldState,
     getAllFieldsFromSections,
-    getBooleanFieldValue,
     getFieldIdFromIdsDictionary,
     getMultipleOptionsFieldValue,
     getStringFieldValue,
@@ -10,7 +9,7 @@ import {
 import { FormState } from "../../../form/presentation-entities/FormState";
 import { ComponentAMCQuestionnaireFormEntity } from "../presentation-entities/QuestionnaireFormEntity";
 import { MapToAMCQuestionnaireParams, MapToFormStateParams } from "./mapperTypes";
-import { getQuestionById, mapToFormOptions } from "./mapperUtils";
+import { getOptionCodeFromFieldValue, getQuestionById, mapToFormOptions } from "./mapperUtils";
 import {
     ComponentAMCQuestionId,
     ComponentAMCQuestionnaire,
@@ -18,7 +17,6 @@ import {
     ComponentAMCQuestionnaireBaseAttributes,
 } from "../../../../../domain/entities/amc-questionnaires/ComponentAMCQuestionnaire";
 import { YesNoUnknownValues } from "../../../../../domain/entities/amc-questionnaires/YesNoUnknownOption";
-import { yesNoOption } from "../../../../../domain/entities/amc-questionnaires/YesNoOption";
 import i18n from "../../../../../locales";
 import { getValidationMessage } from "../../../../../domain/entities/amc-questionnaires/ValidationError";
 
@@ -42,16 +40,18 @@ export function mapFormStateToComponentAMCQuestionnaire(
     const antituberculosisStratum = getStratum("antituberculosisStratum");
     const antimalariaStratum = getStratum("antimalariaStratum");
 
-    const excludedSubstances = options.yesNoUnknownOptions.find(
-        option => option.code === getStringFieldValue("excludedSubstances", allFields)
-    )?.code;
+    const excludedSubstances = getOptionCodeFromFieldValue(
+        "excludedSubstances",
+        options.yesNoUnknownOptions,
+        allFields
+    );
     const listOfExcludedSubstances = getStringFieldValue("listOfExcludedSubstances", allFields);
-    const typeOfDataReported = options.dataLevelOptions.find(
-        option => option.code === getStringFieldValue("typeOfDataReported", allFields)
-    )?.code;
-    const procurementTypeOfDataReported = options.procurementLevelOptions.find(
-        option => option.code === getStringFieldValue("procurementTypeOfDataReported", allFields)
-    )?.code;
+    const typeOfDataReported = getOptionCodeFromFieldValue("typeOfDataReported", options.dataLevelOptions, allFields);
+    const procurementTypeOfDataReported = getOptionCodeFromFieldValue(
+        "procurementTypeOfDataReported",
+        options.procurementLevelOptions,
+        allFields
+    );
     const mixedTypeOfData = getStringFieldValue("mixedTypeOfData", allFields);
     const sourcesOfDataReported = _.compact(
         getMultipleOptionsFieldValue("sourcesOfDataReported", allFields).map(selectedOption => {
@@ -59,15 +59,19 @@ export function mapFormStateToComponentAMCQuestionnaire(
         })
     );
     const commentsForDataSources = getStringFieldValue("commentsForDataSources", allFields);
-    const sameAsUNPopulation = yesNoOption.getValueFromBoolean(getBooleanFieldValue("sameAsUNPopulation", allFields));
-    const sourceOfNationalPopulation = options.nationalPopulationDataSourceOptions.find(
-        option => option.code === getStringFieldValue("sourceOfNationalPopulation", allFields)
-    )?.code;
+    const sameAsUNPopulation = getOptionCodeFromFieldValue("sameAsUNPopulation", options.yesNoOptions, allFields);
+    const sourceOfNationalPopulation = getOptionCodeFromFieldValue(
+        "sourceOfNationalPopulation",
+        options.nationalPopulationDataSourceOptions,
+        allFields
+    );
     const otherSourceForNationalPopulation = getStringFieldValue("otherSourceForNationalPopulation", allFields);
     const commentOnNationalPopulation = getStringFieldValue("commentOnNationalPopulation", allFields);
-    const coverageVolumeWithinTheStratum = options.proportion50to100UnknownOptions.find(
-        option => option.code === getStringFieldValue("coverageVolumeWithinTheStratum", allFields)
-    )?.code;
+    const coverageVolumeWithinTheStratum = getOptionCodeFromFieldValue(
+        "coverageVolumeWithinTheStratum",
+        options.proportion50to100UnknownOptions,
+        allFields
+    );
     const commentOnCoverageWithinTheStratum = getStringFieldValue("commentOnCoverageWithinTheStratum", allFields);
 
     if (
@@ -331,12 +335,10 @@ export function mapComponentAMCQuestionnaireToInitialFormState(
                         id: fromIdsDictionary("sameAsUNPopulation"),
                         isVisible: true,
                         errors: [],
-                        type: "boolean",
-                        label: i18n.t("Yes"),
-                        value:
-                            yesNoOption.getBooleanFromValue(
-                                questionnaireFormEntity?.entity?.sameAsUNPopulation || "0"
-                            ) || false,
+                        type: "radio",
+                        multiple: false,
+                        options: mapToFormOptions(options.yesNoOptions),
+                        value: questionnaireFormEntity?.entity?.sameAsUNPopulation || "",
                         required: true,
                         showIsRequired: true,
                         text: fromQuestions("sameAsUNPopulation"),

--- a/src/webapp/components/current-data-submission/amc-questionnaires/mappers/generalAMCQuestionnaireMapper.ts
+++ b/src/webapp/components/current-data-submission/amc-questionnaires/mappers/generalAMCQuestionnaireMapper.ts
@@ -4,10 +4,12 @@ import {
     GeneralAMCQuestionnaireAttributes,
     GeneralAMCQuestionnaireBaseAttributes,
 } from "../../../../../domain/entities/amc-questionnaires/GeneralAMCQuestionnaire";
+import { yesNoOption } from "../../../../../domain/entities/amc-questionnaires/YesNoOption";
 import { YesNoUnknownValues } from "../../../../../domain/entities/amc-questionnaires/YesNoUnknownOption";
 import {
     FormFieldState,
     getAllFieldsFromSections,
+    getBooleanFieldValue,
     getFieldIdFromIdsDictionary,
     getStringFieldValue,
 } from "../../../form/presentation-entities/FormFieldsState";
@@ -15,6 +17,7 @@ import { FormState } from "../../../form/presentation-entities/FormState";
 import { GeneralAMCQuestionnaireFormEntity } from "../presentation-entities/QuestionnaireFormEntity";
 import { MapToAMCQuestionnaireParams, MapToFormStateParams } from "./mapperTypes";
 import { getOptionCodeFromFieldValue, getQuestionTextsByQuestionId, mapToFormOptions } from "./mapperUtils";
+import i18n from "@eyeseetea/d2-ui-components/locales";
 
 export function mapFormStateToGeneralAMCQuestionnaire(
     params: MapToAMCQuestionnaireParams<GeneralAMCQuestionnaireFormEntity>
@@ -36,11 +39,11 @@ export function mapFormStateToGeneralAMCQuestionnaire(
     )?.code;
     const detailOnShortageInPrivateSector = getStringFieldValue("detailOnShortageInPrivateSector", allFields);
     const generalComments = getStringFieldValue("generalComments", allFields);
-    const antibacterials = getOptionCodeFromFieldValue("antibacterials", options.yesNoOptions, allFields);
-    const antifungals = getOptionCodeFromFieldValue("antifungals", options.yesNoOptions, allFields);
-    const antivirals = getOptionCodeFromFieldValue("antivirals", options.yesNoOptions, allFields);
-    const antituberculosis = getOptionCodeFromFieldValue("antituberculosis", options.yesNoOptions, allFields);
-    const antimalaria = getOptionCodeFromFieldValue("antimalaria", options.yesNoOptions, allFields);
+    const antibacterials = yesNoOption.getValueFromBoolean(getBooleanFieldValue("antibacterials", allFields));
+    const antifungals = yesNoOption.getValueFromBoolean(getBooleanFieldValue("antifungals", allFields));
+    const antivirals = yesNoOption.getValueFromBoolean(getBooleanFieldValue("antivirals", allFields));
+    const antituberculosis = yesNoOption.getValueFromBoolean(getBooleanFieldValue("antituberculosis", allFields));
+    const antimalaria = yesNoOption.getValueFromBoolean(getBooleanFieldValue("antimalaria", allFields));
 
     if (
         !isSameAsLastYear ||
@@ -259,10 +262,11 @@ export function mapGeneralAMCQuestionnaireToInitialFormState(
                         id: fromIdsDictionary("antibacterials"),
                         isVisible: true,
                         errors: [],
-                        type: "radio",
-                        multiple: false,
-                        options: mapToFormOptions(options.yesNoOptions),
-                        value: questionnaireFormEntity?.entity?.antibacterials || "",
+                        type: "boolean",
+                        label: i18n.t("Yes"),
+                        value:
+                            yesNoOption.getBooleanFromValue(questionnaireFormEntity?.entity?.antibacterials || "0") ||
+                            false,
                         required: true,
                         showIsRequired: true,
                         disabled: isViewOnlyMode || !!amcQuestionnaire?.hasAMClassForm("antibacterials"),
@@ -272,10 +276,11 @@ export function mapGeneralAMCQuestionnaireToInitialFormState(
                         id: fromIdsDictionary("antifungals"),
                         isVisible: true,
                         errors: [],
-                        type: "radio",
-                        multiple: false,
-                        options: mapToFormOptions(options.yesNoOptions),
-                        value: questionnaireFormEntity?.entity?.antifungals || "",
+                        type: "boolean",
+                        label: i18n.t("Yes"),
+                        value:
+                            yesNoOption.getBooleanFromValue(questionnaireFormEntity?.entity?.antifungals || "0") ||
+                            false,
                         required: true,
                         showIsRequired: true,
                         disabled: isViewOnlyMode || !!amcQuestionnaire?.hasAMClassForm("antifungals"),
@@ -285,10 +290,11 @@ export function mapGeneralAMCQuestionnaireToInitialFormState(
                         id: fromIdsDictionary("antivirals"),
                         isVisible: true,
                         errors: [],
-                        type: "radio",
-                        multiple: false,
-                        options: mapToFormOptions(options.yesNoOptions),
-                        value: questionnaireFormEntity?.entity?.antivirals || "",
+                        type: "boolean",
+                        label: i18n.t("Yes"),
+                        value:
+                            yesNoOption.getBooleanFromValue(questionnaireFormEntity?.entity?.antivirals || "0") ||
+                            false,
                         required: true,
                         showIsRequired: true,
                         disabled: isViewOnlyMode || !!amcQuestionnaire?.hasAMClassForm("antivirals"),
@@ -298,10 +304,11 @@ export function mapGeneralAMCQuestionnaireToInitialFormState(
                         id: fromIdsDictionary("antituberculosis"),
                         isVisible: true,
                         errors: [],
-                        type: "radio",
-                        multiple: false,
-                        options: mapToFormOptions(options.yesNoOptions),
-                        value: questionnaireFormEntity?.entity?.antituberculosis || "",
+                        type: "boolean",
+                        label: i18n.t("Yes"),
+                        value:
+                            yesNoOption.getBooleanFromValue(questionnaireFormEntity?.entity?.antituberculosis || "0") ||
+                            false,
                         required: true,
                         showIsRequired: true,
                         disabled: isViewOnlyMode || !!amcQuestionnaire?.hasAMClassForm("antituberculosis"),
@@ -311,10 +318,11 @@ export function mapGeneralAMCQuestionnaireToInitialFormState(
                         id: fromIdsDictionary("antimalaria"),
                         isVisible: true,
                         errors: [],
-                        type: "radio",
-                        multiple: false,
-                        options: mapToFormOptions(options.yesNoOptions),
-                        value: questionnaireFormEntity?.entity?.antimalaria || "",
+                        type: "boolean",
+                        label: i18n.t("Yes"),
+                        value:
+                            yesNoOption.getBooleanFromValue(questionnaireFormEntity?.entity?.antimalaria || "0") ||
+                            false,
                         required: true,
                         showIsRequired: true,
                         disabled: isViewOnlyMode || !!amcQuestionnaire?.hasAMClassForm("antimalaria"),

--- a/src/webapp/components/current-data-submission/amc-questionnaires/mappers/generalAMCQuestionnaireMapper.ts
+++ b/src/webapp/components/current-data-submission/amc-questionnaires/mappers/generalAMCQuestionnaireMapper.ts
@@ -4,20 +4,17 @@ import {
     GeneralAMCQuestionnaireAttributes,
     GeneralAMCQuestionnaireBaseAttributes,
 } from "../../../../../domain/entities/amc-questionnaires/GeneralAMCQuestionnaire";
-import { yesNoOption } from "../../../../../domain/entities/amc-questionnaires/YesNoOption";
 import { YesNoUnknownValues } from "../../../../../domain/entities/amc-questionnaires/YesNoUnknownOption";
 import {
     FormFieldState,
     getAllFieldsFromSections,
-    getBooleanFieldValue,
     getFieldIdFromIdsDictionary,
     getStringFieldValue,
 } from "../../../form/presentation-entities/FormFieldsState";
 import { FormState } from "../../../form/presentation-entities/FormState";
 import { GeneralAMCQuestionnaireFormEntity } from "../presentation-entities/QuestionnaireFormEntity";
 import { MapToAMCQuestionnaireParams, MapToFormStateParams } from "./mapperTypes";
-import { getQuestionById, mapToFormOptions } from "./mapperUtils";
-import i18n from "../../../../../locales";
+import { getOptionCodeFromFieldValue, getQuestionById, mapToFormOptions } from "./mapperUtils";
 
 export function mapFormStateToGeneralAMCQuestionnaire(
     params: MapToAMCQuestionnaireParams<GeneralAMCQuestionnaireFormEntity>
@@ -27,23 +24,23 @@ export function mapFormStateToGeneralAMCQuestionnaire(
 
     const allFields: FormFieldState[] = getAllFieldsFromSections(formState.sections);
 
-    const isSameAsLastYear = options.yesNoUnknownNAOptions.find(
-        option => option.code === getStringFieldValue("sameAsLastYear", allFields)
-    )?.code;
-    const shortageInPublicSector = options.yesNoUnknownOptions.find(
-        option => option.code === getStringFieldValue("shortageInPublicSector", allFields)
-    )?.code;
+    const isSameAsLastYear = getOptionCodeFromFieldValue("sameAsLastYear", options.yesNoUnknownNAOptions, allFields);
+    const shortageInPublicSector = getOptionCodeFromFieldValue(
+        "shortageInPublicSector",
+        options.yesNoUnknownOptions,
+        allFields
+    );
     const detailOnShortageInPublicSector = getStringFieldValue("detailOnShortageInPublicSector", allFields);
     const shortageInPrivateSector = options.yesNoUnknownOptions.find(
         option => option.code === getStringFieldValue("shortageInPrivateSector", allFields)
     )?.code;
     const detailOnShortageInPrivateSector = getStringFieldValue("detailOnShortageInPrivateSector", allFields);
     const generalComments = getStringFieldValue("generalComments", allFields);
-    const antibacterials = yesNoOption.getValueFromBoolean(getBooleanFieldValue("antibacterials", allFields));
-    const antifungals = yesNoOption.getValueFromBoolean(getBooleanFieldValue("antifungals", allFields));
-    const antivirals = yesNoOption.getValueFromBoolean(getBooleanFieldValue("antivirals", allFields));
-    const antituberculosis = yesNoOption.getValueFromBoolean(getBooleanFieldValue("antituberculosis", allFields));
-    const antimalaria = yesNoOption.getValueFromBoolean(getBooleanFieldValue("antimalaria", allFields));
+    const antibacterials = getOptionCodeFromFieldValue("antibacterials", options.yesNoOptions, allFields);
+    const antifungals = getOptionCodeFromFieldValue("antifungals", options.yesNoOptions, allFields);
+    const antivirals = getOptionCodeFromFieldValue("antivirals", options.yesNoOptions, allFields);
+    const antituberculosis = getOptionCodeFromFieldValue("antituberculosis", options.yesNoOptions, allFields);
+    const antimalaria = getOptionCodeFromFieldValue("antimalaria", options.yesNoOptions, allFields);
 
     if (
         !isSameAsLastYear ||
@@ -261,11 +258,10 @@ export function mapGeneralAMCQuestionnaireToInitialFormState(
                         id: fromIdsDictionary("antibacterials"),
                         isVisible: true,
                         errors: [],
-                        type: "boolean",
-                        label: i18n.t("Yes"),
-                        value:
-                            yesNoOption.getBooleanFromValue(questionnaireFormEntity?.entity?.antibacterials || "0") ||
-                            false,
+                        type: "radio",
+                        multiple: false,
+                        options: mapToFormOptions(options.yesNoOptions),
+                        value: questionnaireFormEntity?.entity?.antibacterials || "",
                         required: true,
                         showIsRequired: true,
                         text: fromQuestions("antibacterials"),
@@ -275,11 +271,10 @@ export function mapGeneralAMCQuestionnaireToInitialFormState(
                         id: fromIdsDictionary("antifungals"),
                         isVisible: true,
                         errors: [],
-                        type: "boolean",
-                        label: i18n.t("Yes"),
-                        value:
-                            yesNoOption.getBooleanFromValue(questionnaireFormEntity?.entity?.antifungals || "0") ||
-                            false,
+                        type: "radio",
+                        multiple: false,
+                        options: mapToFormOptions(options.yesNoOptions),
+                        value: questionnaireFormEntity?.entity?.antifungals || "",
                         required: true,
                         showIsRequired: true,
                         text: fromQuestions("antifungals"),
@@ -289,11 +284,10 @@ export function mapGeneralAMCQuestionnaireToInitialFormState(
                         id: fromIdsDictionary("antivirals"),
                         isVisible: true,
                         errors: [],
-                        type: "boolean",
-                        label: i18n.t("Yes"),
-                        value:
-                            yesNoOption.getBooleanFromValue(questionnaireFormEntity?.entity?.antivirals || "0") ||
-                            false,
+                        type: "radio",
+                        multiple: false,
+                        options: mapToFormOptions(options.yesNoOptions),
+                        value: questionnaireFormEntity?.entity?.antivirals || "",
                         required: true,
                         showIsRequired: true,
                         text: fromQuestions("antivirals"),
@@ -303,11 +297,10 @@ export function mapGeneralAMCQuestionnaireToInitialFormState(
                         id: fromIdsDictionary("antituberculosis"),
                         isVisible: true,
                         errors: [],
-                        type: "boolean",
-                        label: i18n.t("Yes"),
-                        value:
-                            yesNoOption.getBooleanFromValue(questionnaireFormEntity?.entity?.antituberculosis || "0") ||
-                            false,
+                        type: "radio",
+                        multiple: false,
+                        options: mapToFormOptions(options.yesNoOptions),
+                        value: questionnaireFormEntity?.entity?.antituberculosis || "",
                         required: true,
                         showIsRequired: true,
                         text: fromQuestions("antituberculosis"),
@@ -317,11 +310,10 @@ export function mapGeneralAMCQuestionnaireToInitialFormState(
                         id: fromIdsDictionary("antimalaria"),
                         isVisible: true,
                         errors: [],
-                        type: "boolean",
-                        label: i18n.t("Yes"),
-                        value:
-                            yesNoOption.getBooleanFromValue(questionnaireFormEntity?.entity?.antimalaria || "0") ||
-                            false,
+                        type: "radio",
+                        multiple: false,
+                        options: mapToFormOptions(options.yesNoOptions),
+                        value: questionnaireFormEntity?.entity?.antimalaria || "",
                         required: true,
                         showIsRequired: true,
                         text: fromQuestions("antimalaria"),

--- a/src/webapp/components/current-data-submission/amc-questionnaires/mappers/mapperUtils.ts
+++ b/src/webapp/components/current-data-submission/amc-questionnaires/mappers/mapperUtils.ts
@@ -2,7 +2,9 @@ import {
     AMCQuestionId,
     AMCQuestionnaireQuestions,
 } from "../../../../../domain/entities/amc-questionnaires/AMCQuestionnaireQuestions";
+import { OptionType } from "../../../../../domain/entities/amc-questionnaires/Option";
 import { AMCQuestionnaireOptionsContextState } from "../../../../contexts/amc-questionnaire-options-context";
+import { FormFieldState, getStringFieldValue } from "../../../form/presentation-entities/FormFieldsState";
 import { FormOption } from "../../../form/presentation-entities/FormOption";
 
 export function mapToFormOptions<
@@ -19,4 +21,12 @@ export function mapToFormOptions<
 
 export function getQuestionById(id: AMCQuestionId, questions: AMCQuestionnaireQuestions): string {
     return questions.find(question => question.id === id)?.text || "";
+}
+
+export function getOptionCodeFromFieldValue<T extends string>(
+    formFieldId: string,
+    options: OptionType<T>[],
+    formFields: FormFieldState[]
+): T | undefined {
+    return options.find(option => option.code === getStringFieldValue(formFieldId, formFields))?.code;
 }


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8699gzr37 #8699gzr37

### :memo: Implementation

- change yes/no options to radio buttons instead of checkbox
- only `sameAsUNPopulation` was changed 
- although AM Class questions in the general form are yes/no options, we keep using checkboxes for them
- extract method `getOptionCodeFromFieldValue`

### :video_camera: Screenshots/Screen capture

### :fire: Testing
