### PR TITLE
fix: EAR save error

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2025-06-03T16:56:09.366Z\n"
-"PO-Revision-Date: 2025-06-03T16:56:09.366Z\n"
+"POT-Creation-Date: 2025-06-26T17:11:26.187Z\n"
+"PO-Revision-Date: 2025-06-26T17:11:26.187Z\n"
 
 msgid "Template {{id}} not loaded"
 msgstr ""
@@ -590,6 +590,9 @@ msgid "OPEN ALL YEAR"
 msgstr ""
 
 msgid "GO"
+msgstr ""
+
+msgid "Submission failed - "
 msgstr ""
 
 msgid "Save Draft"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2025-06-03T16:56:09.366Z\n"
+"POT-Creation-Date: 2025-06-26T17:11:26.187Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -592,6 +592,9 @@ msgid "OPEN ALL YEAR"
 msgstr ""
 
 msgid "GO"
+msgstr ""
+
+msgid "Submission failed - "
 msgstr ""
 
 msgid "Save Draft"

--- a/src/data/repositories/CaptureFormDefaultRepository.ts
+++ b/src/data/repositories/CaptureFormDefaultRepository.ts
@@ -14,6 +14,7 @@ import {
 import { apiToFuture } from "../../utils/futures";
 import { D2TrackerEvent } from "@eyeseetea/d2-api/api/trackerEvents";
 import { Id } from "../../domain/entities/Ref";
+import { parseDate } from "../../utils/dates";
 
 interface EARProgram {
     code: string;
@@ -241,7 +242,7 @@ export class CaptureFormDefaultRepository implements CaptureFormRepository {
                                 code: curDE.code,
                                 text: curDE.formName,
                                 type: "date",
-                                value: dataValue ? new Date(dataValue.value as string) : new Date(),
+                                value: dataValue ? parseDate(dataValue.value) : new Date(),
                             };
 
                             return dateQ;

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -1,0 +1,22 @@
+import moment from "moment";
+
+/**
+ * Returns a formatted date string in the format YYYY-MM-DD using the current locale.
+ * If the date is invalid, it returns an empty string.
+ */
+export function formatDate(date: Date): string {
+    if (!date || isNaN(date.getTime())) return "";
+    return moment(date).format("YYYY-MM-DD");
+}
+
+/**
+ * Parses a date string in YYYY-MM-DD format using the current locale and returns a Date object.
+ * @throws Error if the date string is invalid.
+ */
+export function parseDate(dateString: string): Date {
+    const m = moment(dateString, "YYYY-MM-DD", true);
+    if (!m.isValid()) {
+        throw new Error(`Invalid date string: ${dateString}`);
+    }
+    return m.toDate();
+}

--- a/src/webapp/components/new-signal/ProgramQuestionnaireForm.tsx
+++ b/src/webapp/components/new-signal/ProgramQuestionnaireForm.tsx
@@ -66,6 +66,21 @@ export const ProgramQuestionnaireForm: React.FC<ProgramQuestionnaireFormProps> =
         props.aggsubQuestionnaires
     );
 
+    const showSubmissionError = React.useCallback(
+        (error: string) => {
+            if (error && error.startsWith("EAR-IMPORT-ERROR:")) {
+                snackbar.error(error.replace("EAR-IMPORT-ERROR:", i18n.t("Submission failed - ")));
+            } else {
+                console.error("Unknown Error during submission:", error);
+                // TODO: return the permissions error from inner layers, use this for unknown errors
+                snackbar.error(
+                    "Submission Failed! You do not have the necessary permissions, please contact your administrator"
+                );
+            }
+        },
+        [snackbar]
+    );
+
     const publishQuestionnaire = () => {
         setLoading(true);
 
@@ -99,12 +114,9 @@ export const ProgramQuestionnaireForm: React.FC<ProgramQuestionnaireFormProps> =
                         setLoading(false);
                         if (props.hideForm) props.hideForm();
                     },
-                    () => {
-                        snackbar.error(
-                            "Submission Failed! You do not have the necessary permissions, please contact your administrator"
-                        );
+                    error => {
+                        showSubmissionError(error);
                         setLoading(false);
-                        if (props.hideForm) props.hideForm();
                     }
                 );
         }
@@ -144,12 +156,9 @@ export const ProgramQuestionnaireForm: React.FC<ProgramQuestionnaireFormProps> =
                         if (props.hideForm) props.hideForm();
                         if (props.refreshGrid) props.refreshGrid({});
                     },
-                    () => {
-                        snackbar.error(
-                            "Submission Failed! You do not have the necessary permissions, please contact your administrator"
-                        );
+                    error => {
+                        showSubmissionError(error);
                         setLoading(false);
-                        if (props.hideForm) props.hideForm();
                     }
                 );
         }


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8699h0rdu #8699h0rdu

### :memo: Implementation

- Tracker import was failing because the dates were not formatted as YYYY-MM-DD. Added formatting for that.
- Improved error handling: there was an uncaught Error after the import failure. 
  - Added a check for the import status and the existance of `bundleReport`.
  - Added handling of these errors in the view to show a more specific message rather than the default one about permissions.
  - After an Error, the user was redirected to the previous screen. Removed these `hideForm()` calls so the user stays in the form in case of save failure.
- Created common utils for parsing and formatting the date as YYYY-MM-DD using the current user locale. 
  - Only implemented in these related areas. We might want to use these in other parts later instead manually formatting each time. 
  - I ended implementing this because doing `dateObjFromDatePicker.toISOString().split("T")?.at(0)`  (like used in `occurredAt`) would lead to saving the previous date for some timezones

I think the undefined error in `bundleReport` property of the importResponse, could have been caught by TypeScript if it was typed as an optional in `d2-api` `TrackerPostResponse` type (or a discriminated union depending on status). 
To check if that would be a good proposal for a change to `d2-api`.

### :video_camera: Screenshots/Screen capture

[glass_save_ear.webm](https://github.com/user-attachments/assets/dadc3006-2afd-4fb6-a89e-5665132283ff)

### :fire: Testing
