### PR TITLE
feat: AMC questionnaire description icon and text

### DIFF
--- a/src/data/repositories/amc-questionnaires/QuestionsAMCQuestionnaireD2Repository.ts
+++ b/src/data/repositories/amc-questionnaires/QuestionsAMCQuestionnaireD2Repository.ts
@@ -26,7 +26,8 @@ export class QuestionsAMCQuestionnaireD2Repository implements QuestionsAMCQuesti
                         ? [
                               ...acc,
                               {
-                                  text: attribute.trackedEntityAttribute.displayDescription || "",
+                                  text: attribute.trackedEntityAttribute.displayFormName || "",
+                                  description: attribute.trackedEntityAttribute.displayDescription || undefined,
                                   id: questionId,
                               },
                           ]
@@ -68,6 +69,7 @@ export class QuestionsAMCQuestionnaireD2Repository implements QuestionsAMCQuesti
                           ...acc,
                           {
                               text: dataElement.dataElement.displayFormName || "",
+                              description: dataElement.dataElement.displayDescription || undefined,
                               id: questionId,
                           },
                       ]

--- a/src/data/repositories/amc-questionnaires/getAMCQuestionnaireProgramMetadata.ts
+++ b/src/data/repositories/amc-questionnaires/getAMCQuestionnaireProgramMetadata.ts
@@ -24,6 +24,7 @@ const programFields = {
         trackedEntityAttribute: {
             id: true,
             code: true,
+            displayFormName: true,
             displayDescription: true,
         },
     },
@@ -38,6 +39,7 @@ const programFields = {
                 id: true,
                 code: true,
                 displayFormName: true,
+                displayDescription: true,
             },
         },
     },

--- a/src/domain/entities/amc-questionnaires/AMCQuestionnaireQuestions.ts
+++ b/src/domain/entities/amc-questionnaires/AMCQuestionnaireQuestions.ts
@@ -6,6 +6,7 @@ export type AMCQuestionId = GeneralAMCQuestionId | AMClassAMCQuestionId | Compon
 
 export type AMCQuestion = {
     text: string;
+    description?: string;
     id: AMCQuestionId;
 };
 

--- a/src/webapp/components/current-data-submission/amc-questionnaires/mappers/amClassAMCQuestionnaireMapper.ts
+++ b/src/webapp/components/current-data-submission/amc-questionnaires/mappers/amClassAMCQuestionnaireMapper.ts
@@ -8,7 +8,7 @@ import {
 import { FormState } from "../../../form/presentation-entities/FormState";
 import { AMClassAMCQuestionnaireFormEntity } from "../presentation-entities/QuestionnaireFormEntity";
 import { MapToAMCQuestionnaireParams, MapToFormStateParams } from "./mapperTypes";
-import { getQuestionById, mapToFormOptions } from "./mapperUtils";
+import { getQuestionTextsByQuestionId, mapToFormOptions } from "./mapperUtils";
 import {
     AMClassAMCQuestionId,
     AMClassAMCQuestionnaire,
@@ -89,7 +89,8 @@ export function mapAMClassAMCQuestionnaireToInitialFormState(
     const fromIdsDictionary = (key: keyof typeof amClassAMCQuestionnaireFieldIds) =>
         getFieldIdFromIdsDictionary(key, amClassAMCQuestionnaireFieldIds);
 
-    const fromQuestions = (id: AMClassAMCQuestionId) => getQuestionById(id, questionnaireFormEntity.questions);
+    const fromQuestions = (id: AMClassAMCQuestionId) =>
+        getQuestionTextsByQuestionId(id, questionnaireFormEntity.questions);
 
     const antimicrobialClassValue = questionnaireFormEntity?.entity?.antimicrobialClass;
     const antimicrobialClassOption = options.antimicrobialClassOptions.find(
@@ -125,8 +126,8 @@ export function mapAMClassAMCQuestionnaireToInitialFormState(
                         options: mapToFormOptions(antimicrobialClassOptinsWithSelf),
                         required: true,
                         showIsRequired: true,
-                        text: fromQuestions("antimicrobialClass"),
                         disabled: isViewOnlyMode,
+                        ...fromQuestions("antimicrobialClass"),
                     },
                     {
                         id: fromIdsDictionary("stratas"),
@@ -138,8 +139,8 @@ export function mapAMClassAMCQuestionnaireToInitialFormState(
                         options: mapToFormOptions(options.strataOptions, disabledStratas),
                         required: true,
                         showIsRequired: true,
-                        text: fromQuestions("stratas"),
                         disabled: isViewOnlyMode,
+                        ...fromQuestions("stratas"),
                     },
                     {
                         id: fromIdsDictionary("estVolumeTotalHealthLevel"),
@@ -151,8 +152,8 @@ export function mapAMClassAMCQuestionnaireToInitialFormState(
                         options: mapToFormOptions(options.proportion50to100Options),
                         required: false,
                         showIsRequired: false,
-                        text: fromQuestions("estVolumeTotalHealthLevel"),
                         disabled: isViewOnlyMode,
+                        ...fromQuestions("estVolumeTotalHealthLevel"),
                     },
                     {
                         id: fromIdsDictionary("estVolumeHospitalHealthLevel"),
@@ -164,8 +165,8 @@ export function mapAMClassAMCQuestionnaireToInitialFormState(
                         options: mapToFormOptions(options.proportion50to100Options),
                         required: false,
                         showIsRequired: false,
-                        text: fromQuestions("estVolumeHospitalHealthLevel"),
                         disabled: isViewOnlyMode,
+                        ...fromQuestions("estVolumeHospitalHealthLevel"),
                     },
                     {
                         id: fromIdsDictionary("estVolumeCommunityHealthLevel"),
@@ -177,8 +178,8 @@ export function mapAMClassAMCQuestionnaireToInitialFormState(
                         options: mapToFormOptions(options.proportion50to100Options),
                         required: false,
                         showIsRequired: false,
-                        text: fromQuestions("estVolumeCommunityHealthLevel"),
                         disabled: isViewOnlyMode,
+                        ...fromQuestions("estVolumeCommunityHealthLevel"),
                     },
                 ],
             },

--- a/src/webapp/components/current-data-submission/amc-questionnaires/mappers/componentAMCQuestionnaireMapper.ts
+++ b/src/webapp/components/current-data-submission/amc-questionnaires/mappers/componentAMCQuestionnaireMapper.ts
@@ -10,7 +10,7 @@ import {
 import { FormState } from "../../../form/presentation-entities/FormState";
 import { ComponentAMCQuestionnaireFormEntity } from "../presentation-entities/QuestionnaireFormEntity";
 import { MapToAMCQuestionnaireParams, MapToFormStateParams } from "./mapperTypes";
-import { getQuestionById, mapToFormOptions } from "./mapperUtils";
+import { getQuestionTextsByQuestionId, mapToFormOptions } from "./mapperUtils";
 import {
     ComponentAMCQuestionId,
     ComponentAMCQuestionnaire,
@@ -170,7 +170,7 @@ function getStratumField(
 ): FormFieldState {
     const { questionnaireFormEntity, options, isViewOnlyMode, amcQuestionnaire } = params;
     const fieldId = getFieldIdFromIdsDictionary(stratumKey, ComponentAMCQuestionnaireFieldIds);
-    const question = getQuestionById(stratumKey, questionnaireFormEntity.questions);
+    const question = getQuestionTextsByQuestionId(stratumKey, questionnaireFormEntity.questions);
     const selfOptions = options.strataOptions.filter(option =>
         (questionnaireFormEntity?.entity?.[stratumKey] ?? []).includes(option.code)
     );
@@ -190,8 +190,8 @@ function getStratumField(
         options: mapToFormOptions(strataOptionsWithSelf),
         required: false,
         showIsRequired: false,
-        text: question,
         disabled: isViewOnlyMode,
+        ...question,
     };
 }
 
@@ -207,7 +207,8 @@ export function mapComponentAMCQuestionnaireToInitialFormState(
     const fromIdsDictionary = (key: keyof typeof ComponentAMCQuestionnaireFieldIds) =>
         getFieldIdFromIdsDictionary(key, ComponentAMCQuestionnaireFieldIds);
 
-    const fromQuestions = (id: ComponentAMCQuestionId) => getQuestionById(id, questionnaireFormEntity.questions);
+    const fromQuestions = (id: ComponentAMCQuestionId) =>
+        getQuestionTextsByQuestionId(id, questionnaireFormEntity.questions);
 
     return {
         id: questionnaireFormEntity.entity?.id ?? "",
@@ -253,8 +254,8 @@ export function mapComponentAMCQuestionnaireToInitialFormState(
                         value: questionnaireFormEntity?.entity?.excludedSubstances || "",
                         required: true,
                         showIsRequired: true,
-                        text: fromQuestions("excludedSubstances"),
                         disabled: isViewOnlyMode,
+                        ...fromQuestions("excludedSubstances"),
                     },
                     {
                         id: fromIdsDictionary("listOfExcludedSubstances"),
@@ -264,8 +265,8 @@ export function mapComponentAMCQuestionnaireToInitialFormState(
                         value: questionnaireFormEntity?.entity?.listOfExcludedSubstances || "",
                         multiline: false,
                         required: YesNoUnknownValues.YES === questionnaireFormEntity?.entity?.excludedSubstances,
-                        text: fromQuestions("listOfExcludedSubstances"),
                         disabled: isViewOnlyMode,
+                        ...fromQuestions("listOfExcludedSubstances"),
                     },
                     {
                         id: fromIdsDictionary("typeOfDataReported"),
@@ -277,8 +278,8 @@ export function mapComponentAMCQuestionnaireToInitialFormState(
                         value: questionnaireFormEntity?.entity?.typeOfDataReported || "",
                         required: true,
                         showIsRequired: true,
-                        text: fromQuestions("typeOfDataReported"),
                         disabled: isViewOnlyMode,
+                        ...fromQuestions("typeOfDataReported"),
                     },
                     {
                         id: fromIdsDictionary("procurementTypeOfDataReported"),
@@ -289,8 +290,8 @@ export function mapComponentAMCQuestionnaireToInitialFormState(
                         options: mapToFormOptions(options.procurementLevelOptions),
                         value: questionnaireFormEntity?.entity?.procurementTypeOfDataReported || "",
                         required: false,
-                        text: fromQuestions("procurementTypeOfDataReported"),
                         disabled: isViewOnlyMode,
+                        ...fromQuestions("procurementTypeOfDataReported"),
                     },
                     {
                         id: fromIdsDictionary("mixedTypeOfData"),
@@ -300,8 +301,8 @@ export function mapComponentAMCQuestionnaireToInitialFormState(
                         value: questionnaireFormEntity?.entity?.mixedTypeOfData || "",
                         multiline: false,
                         required: false,
-                        text: fromQuestions("mixedTypeOfData"),
                         disabled: isViewOnlyMode,
+                        ...fromQuestions("mixedTypeOfData"),
                     },
                     {
                         id: fromIdsDictionary("sourcesOfDataReported"),
@@ -313,8 +314,8 @@ export function mapComponentAMCQuestionnaireToInitialFormState(
                         options: mapToFormOptions(options.dataSourceOptions),
                         required: true,
                         showIsRequired: true,
-                        text: fromQuestions("sourcesOfDataReported"),
                         disabled: isViewOnlyMode,
+                        ...fromQuestions("sourcesOfDataReported"),
                     },
                     {
                         id: fromIdsDictionary("commentsForDataSources"),
@@ -324,8 +325,8 @@ export function mapComponentAMCQuestionnaireToInitialFormState(
                         value: questionnaireFormEntity?.entity?.commentsForDataSources || "",
                         multiline: false,
                         required: false,
-                        text: fromQuestions("commentsForDataSources"),
                         disabled: isViewOnlyMode,
+                        ...fromQuestions("commentsForDataSources"),
                     },
                     {
                         id: fromIdsDictionary("sameAsUNPopulation"),
@@ -339,8 +340,8 @@ export function mapComponentAMCQuestionnaireToInitialFormState(
                             ) || false,
                         required: true,
                         showIsRequired: true,
-                        text: fromQuestions("sameAsUNPopulation"),
                         disabled: isViewOnlyMode,
+                        ...fromQuestions("sameAsUNPopulation"),
                     },
                     {
                         id: fromIdsDictionary("sourceOfNationalPopulation"),
@@ -351,8 +352,8 @@ export function mapComponentAMCQuestionnaireToInitialFormState(
                         options: mapToFormOptions(options.nationalPopulationDataSourceOptions),
                         value: questionnaireFormEntity?.entity?.sourceOfNationalPopulation || "",
                         required: false,
-                        text: fromQuestions("sourceOfNationalPopulation"),
                         disabled: isViewOnlyMode,
+                        ...fromQuestions("sourceOfNationalPopulation"),
                     },
                     {
                         id: fromIdsDictionary("otherSourceForNationalPopulation"),
@@ -362,8 +363,8 @@ export function mapComponentAMCQuestionnaireToInitialFormState(
                         value: questionnaireFormEntity?.entity?.otherSourceForNationalPopulation || "",
                         multiline: false,
                         required: false,
-                        text: fromQuestions("otherSourceForNationalPopulation"),
                         disabled: isViewOnlyMode,
+                        ...fromQuestions("otherSourceForNationalPopulation"),
                     },
                     {
                         id: fromIdsDictionary("commentOnNationalPopulation"),
@@ -373,8 +374,8 @@ export function mapComponentAMCQuestionnaireToInitialFormState(
                         value: questionnaireFormEntity?.entity?.commentOnNationalPopulation || "",
                         multiline: false,
                         required: false,
-                        text: fromQuestions("commentOnNationalPopulation"),
                         disabled: isViewOnlyMode,
+                        ...fromQuestions("commentOnNationalPopulation"),
                     },
                     {
                         id: fromIdsDictionary("coverageVolumeWithinTheStratum"),
@@ -386,8 +387,8 @@ export function mapComponentAMCQuestionnaireToInitialFormState(
                         value: questionnaireFormEntity?.entity?.coverageVolumeWithinTheStratum || "",
                         required: true,
                         showIsRequired: true,
-                        text: fromQuestions("coverageVolumeWithinTheStratum"),
                         disabled: isViewOnlyMode,
+                        ...fromQuestions("coverageVolumeWithinTheStratum"),
                     },
                     {
                         id: fromIdsDictionary("commentOnCoverageWithinTheStratum"),
@@ -397,8 +398,8 @@ export function mapComponentAMCQuestionnaireToInitialFormState(
                         value: questionnaireFormEntity?.entity?.commentOnCoverageWithinTheStratum || "",
                         multiline: false,
                         required: false,
-                        text: fromQuestions("commentOnCoverageWithinTheStratum"),
                         disabled: isViewOnlyMode,
+                        ...fromQuestions("commentOnCoverageWithinTheStratum"),
                     },
                 ],
             },

--- a/src/webapp/components/current-data-submission/amc-questionnaires/mappers/generalAMCQuestionnaireMapper.ts
+++ b/src/webapp/components/current-data-submission/amc-questionnaires/mappers/generalAMCQuestionnaireMapper.ts
@@ -16,7 +16,7 @@ import {
 import { FormState } from "../../../form/presentation-entities/FormState";
 import { GeneralAMCQuestionnaireFormEntity } from "../presentation-entities/QuestionnaireFormEntity";
 import { MapToAMCQuestionnaireParams, MapToFormStateParams } from "./mapperTypes";
-import { getQuestionById, mapToFormOptions } from "./mapperUtils";
+import { getQuestionTextsByQuestionId, mapToFormOptions } from "./mapperUtils";
 import i18n from "../../../../../locales";
 
 export function mapFormStateToGeneralAMCQuestionnaire(
@@ -140,7 +140,8 @@ export function mapGeneralAMCQuestionnaireToInitialFormState(
     const fromIdsDictionary = (key: keyof typeof generalAMCQuestionnaireFieldIds) =>
         getFieldIdFromIdsDictionary(key, generalAMCQuestionnaireFieldIds);
 
-    const fromQuestions = (id: GeneralAMCQuestionId) => getQuestionById(id, questionnaireFormEntity.questions);
+    const fromQuestions = (id: GeneralAMCQuestionId) =>
+        getQuestionTextsByQuestionId(id, questionnaireFormEntity.questions);
 
     return {
         id: questionnaireFormEntity?.entity?.id || "",
@@ -163,8 +164,8 @@ export function mapGeneralAMCQuestionnaireToInitialFormState(
                         options: mapToFormOptions(options.yesNoUnknownNAOptions),
                         required: true,
                         showIsRequired: true,
-                        text: fromQuestions("isSameAsLastYear"),
                         disabled: isViewOnlyMode,
+                        ...fromQuestions("isSameAsLastYear"),
                     },
                 ],
             },
@@ -184,8 +185,8 @@ export function mapGeneralAMCQuestionnaireToInitialFormState(
                         value: questionnaireFormEntity?.entity?.shortageInPublicSector || "",
                         required: true,
                         showIsRequired: true,
-                        text: fromQuestions("shortageInPublicSector"),
                         disabled: isViewOnlyMode,
+                        ...fromQuestions("shortageInPublicSector"),
                     },
                     {
                         id: fromIdsDictionary("detailOnShortageInPublicSector"),
@@ -195,8 +196,8 @@ export function mapGeneralAMCQuestionnaireToInitialFormState(
                         value: questionnaireFormEntity?.entity?.detailOnShortageInPublicSector || "",
                         multiline: false,
                         required: YesNoUnknownValues.YES === questionnaireFormEntity?.entity?.shortageInPublicSector,
-                        text: fromQuestions("detailOnShortageInPublicSector"),
                         disabled: isViewOnlyMode,
+                        ...fromQuestions("detailOnShortageInPublicSector"),
                     },
                 ],
             },
@@ -216,8 +217,8 @@ export function mapGeneralAMCQuestionnaireToInitialFormState(
                         value: questionnaireFormEntity?.entity?.shortageInPrivateSector || "",
                         required: true,
                         showIsRequired: true,
-                        text: fromQuestions("shortageInPrivateSector"),
                         disabled: isViewOnlyMode,
+                        ...fromQuestions("shortageInPrivateSector"),
                     },
                     {
                         id: fromIdsDictionary("detailOnShortageInPrivateSector"),
@@ -227,8 +228,8 @@ export function mapGeneralAMCQuestionnaireToInitialFormState(
                         value: questionnaireFormEntity?.entity?.detailOnShortageInPrivateSector || "",
                         multiline: false,
                         required: YesNoUnknownValues.YES === questionnaireFormEntity?.entity?.shortageInPrivateSector,
-                        text: fromQuestions("detailOnShortageInPrivateSector"),
                         disabled: isViewOnlyMode,
+                        ...fromQuestions("detailOnShortageInPrivateSector"),
                     },
                 ],
             },
@@ -246,8 +247,8 @@ export function mapGeneralAMCQuestionnaireToInitialFormState(
                         value: questionnaireFormEntity?.entity?.generalComments || "",
                         multiline: false,
                         required: false,
-                        text: fromQuestions("generalComments"),
                         disabled: isViewOnlyMode,
+                        ...fromQuestions("generalComments"),
                     },
                 ],
             },
@@ -268,8 +269,8 @@ export function mapGeneralAMCQuestionnaireToInitialFormState(
                             false,
                         required: true,
                         showIsRequired: true,
-                        text: fromQuestions("antibacterials"),
                         disabled: isViewOnlyMode || !!amcQuestionnaire?.hasAMClassForm("antibacterials"),
+                        ...fromQuestions("antibacterials"),
                     },
                     {
                         id: fromIdsDictionary("antifungals"),
@@ -282,8 +283,8 @@ export function mapGeneralAMCQuestionnaireToInitialFormState(
                             false,
                         required: true,
                         showIsRequired: true,
-                        text: fromQuestions("antifungals"),
                         disabled: isViewOnlyMode || !!amcQuestionnaire?.hasAMClassForm("antifungals"),
+                        ...fromQuestions("antifungals"),
                     },
                     {
                         id: fromIdsDictionary("antivirals"),
@@ -296,8 +297,8 @@ export function mapGeneralAMCQuestionnaireToInitialFormState(
                             false,
                         required: true,
                         showIsRequired: true,
-                        text: fromQuestions("antivirals"),
                         disabled: isViewOnlyMode || !!amcQuestionnaire?.hasAMClassForm("antivirals"),
+                        ...fromQuestions("antivirals"),
                     },
                     {
                         id: fromIdsDictionary("antituberculosis"),
@@ -310,8 +311,8 @@ export function mapGeneralAMCQuestionnaireToInitialFormState(
                             false,
                         required: true,
                         showIsRequired: true,
-                        text: fromQuestions("antituberculosis"),
                         disabled: isViewOnlyMode || !!amcQuestionnaire?.hasAMClassForm("antituberculosis"),
+                        ...fromQuestions("antituberculosis"),
                     },
                     {
                         id: fromIdsDictionary("antimalaria"),
@@ -324,8 +325,8 @@ export function mapGeneralAMCQuestionnaireToInitialFormState(
                             false,
                         required: true,
                         showIsRequired: true,
-                        text: fromQuestions("antimalaria"),
                         disabled: isViewOnlyMode || !!amcQuestionnaire?.hasAMClassForm("antimalaria"),
+                        ...fromQuestions("antimalaria"),
                     },
                 ],
             },

--- a/src/webapp/components/current-data-submission/amc-questionnaires/mappers/mapperUtils.ts
+++ b/src/webapp/components/current-data-submission/amc-questionnaires/mappers/mapperUtils.ts
@@ -17,6 +17,17 @@ export function mapToFormOptions<
     );
 }
 
-export function getQuestionById(id: AMCQuestionId, questions: AMCQuestionnaireQuestions): string {
-    return questions.find(question => question.id === id)?.text || "";
+export function getQuestionTextsByQuestionId(
+    id: AMCQuestionId,
+    questions: AMCQuestionnaireQuestions
+): { text: string; infoTooltipText?: string } {
+    const question = questions.find(question => question.id === id);
+    if (!question) {
+        console.warn(`Question with id ${id} not found.`);
+        return { text: "", infoTooltipText: undefined };
+    }
+    return {
+        text: question.text,
+        infoTooltipText: question.description,
+    };
 }

--- a/src/webapp/components/form/FormSection.tsx
+++ b/src/webapp/components/form/FormSection.tsx
@@ -5,6 +5,8 @@ import { DataTable, TableHead, DataTableRow, DataTableColumnHeader, TableBody, D
 
 import { FieldWidget } from "./FieldWidget";
 import { FormFieldState } from "./presentation-entities/FormFieldsState";
+import { InfoTooltip } from "./InfoTooltip";
+import { palette } from "../../pages/app/themes/dhis2.theme";
 
 type FormSectionProps = {
     id: string;
@@ -33,7 +35,10 @@ export const FormSection: React.FC<FormSectionProps> = React.memo(({ title, fiel
                           return (
                               <StyledDataTableRow key={field.id}>
                                   <DataTableCell width="60%">
-                                      <StyledTextField required={field.required || false}>{field.text}</StyledTextField>
+                                      <StyledTextField required={field.required || false} disabled={field.disabled}>
+                                          {field.text}
+                                      </StyledTextField>
+                                      {field.infoTooltipText && <InfoTooltip text={field.infoTooltipText} />}
                                   </DataTableCell>
 
                                   <DataTableCell>
@@ -65,9 +70,10 @@ const StyledDataTableRow = styled(DataTableRow)`
     }
 `;
 
-const StyledTextField = styled.span<{ required: boolean }>`
+const StyledTextField = styled.span<{ required: boolean; disabled?: boolean }>`
     ::after {
         content: ${props => (props.required ? "'*'" : "''")};
         margin-inline-start: 4px;
+        color: ${props => (props.required && !props.disabled ? palette.error.main : "inherit")};
     }
 `;

--- a/src/webapp/components/form/InfoTooltip.tsx
+++ b/src/webapp/components/form/InfoTooltip.tsx
@@ -1,0 +1,49 @@
+import i18n from "@eyeseetea/d2-ui-components/locales";
+import { Box, ClickAwayListener, makeStyles, Tooltip, Typography } from "@material-ui/core";
+import InfoOutlinedIcon from "@material-ui/icons/InfoOutlined";
+import React from "react";
+import { palette, muiTheme } from "../../pages/app/themes/dhis2.theme";
+
+export type InfoTooltipProps = {
+    text: string;
+};
+const useStyles = makeStyles(() => ({
+    tooltip: {
+        backgroundColor: palette.background.paper,
+        boxShadow: muiTheme.shadows[1],
+        color: "#212934",
+        border: `1px solid ${palette.background.default}`,
+    },
+    icon: {
+        fontSize: 18,
+        marginLeft: 8,
+        verticalAlign: "middle",
+        cursor: "pointer",
+        color: palette.shadow,
+    },
+}));
+
+export const InfoTooltip: React.FC<InfoTooltipProps> = React.memo(({ text }) => {
+    const classes = useStyles();
+    const [open, setOpen] = React.useState(false);
+    return (
+        <ClickAwayListener onClickAway={() => setOpen(false)}>
+            <Tooltip
+                title={
+                    <Box>
+                        <Typography variant="subtitle2">{i18n.t("Description")}</Typography>
+                        <Typography style={{ fontSize: "14px", fontWeight: "normal" }} variant="caption">
+                            {text}
+                        </Typography>
+                    </Box>
+                }
+                disableHoverListener
+                open={open}
+                onClick={() => setOpen(!open)}
+                classes={{ tooltip: classes.tooltip }}
+            >
+                <InfoOutlinedIcon classes={{ root: classes.icon }} tabIndex={0} aria-label="Helper information" />
+            </Tooltip>
+        </ClickAwayListener>
+    );
+});

--- a/src/webapp/components/form/presentation-entities/FormFieldsState.ts
+++ b/src/webapp/components/form/presentation-entities/FormFieldsState.ts
@@ -10,6 +10,7 @@ type FormFieldStateBase<T> = {
     label?: string;
     text?: string;
     placeholder?: string;
+    infoTooltipText?: string;
     helperText?: string;
     errors: string[];
     required?: boolean;


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8699n78kg #8699n78kg

### :memo: Implementation

This PR updates the display text to always show the Form Name. If a Description is present, an "info" icon appears next to the name. Clicking the icon opens a tooltip showing the description, matching the behavior in the Capture App as requested.
Additionally, the * required field indicator is now red during form editing, for consistency with Capture (this was not requested but thought it was a good idea).

- Change mappings to use `displayFormName` as `text` and `displayDescription` as `description` in `AMCQuestion` for both TEAs and DEs
- Add new optional prop `infoTooltipText` to `FormFieldStateBase`, that when set will render the `InfoTooltip` component.
- Change mappings from `AMCQuestion` to `FormFieldState`:
  - `getQuestionById` that was returning the question `text`, changed to `getQuestionTextsByQuestionId` that now should return all question texts

### :video_camera: Screenshots/Screen capture

![imagen](https://github.com/user-attachments/assets/b193fe0d-188d-4629-aa86-4ed8cdd618ee)


### :fire: Testing
