### PR TITLE
AMC Data Questionnaire fixes - Change Id of OptionSet and Change names of sections

### DIFF
--- a/src/data/repositories/amc-questionnaires/DataSourceOptionsD2Repository.ts
+++ b/src/data/repositories/amc-questionnaires/DataSourceOptionsD2Repository.ts
@@ -6,7 +6,7 @@ export class DataSourceOptionsD2Repository
     extends OptionsD2Repository<DataSourceValue>
     implements DataSourceOptionsRepository
 {
-    protected optionSetCode = "YxVWiSz3pVA";
+    protected optionSetCode = "KxaU7AN3WyS";
     protected optionSetName = "Data Source OptionSet";
     protected options = dataSourceOption;
 }

--- a/src/webapp/components/current-data-submission/amc-questionnaires/mappers/amClassAMCQuestionnaireMapper.ts
+++ b/src/webapp/components/current-data-submission/amc-questionnaires/mappers/amClassAMCQuestionnaireMapper.ts
@@ -106,11 +106,11 @@ export function mapAMClassAMCQuestionnaireToInitialFormState(
 
     return {
         id: questionnaireFormEntity.entity?.id ?? "",
-        title: "AM Class questionnaire",
+        title: "Antimicrobial classes questionnaire",
         isValid: false,
         sections: [
             {
-                title: "AM Class General questionnaire",
+                title: "Antimicrobial classes ",
                 id: "general_section",
                 isVisible: true,
                 required: true,

--- a/src/webapp/components/current-data-submission/amc-questionnaires/mappers/generalAMCQuestionnaireMapper.ts
+++ b/src/webapp/components/current-data-submission/amc-questionnaires/mappers/generalAMCQuestionnaireMapper.ts
@@ -148,7 +148,7 @@ export function mapGeneralAMCQuestionnaireToInitialFormState(
         isValid: false,
         sections: [
             {
-                title: "General questionnaire",
+                title: "Data comparability with previous year's data",
                 id: "general_section",
                 isVisible: true,
                 required: true,
@@ -169,7 +169,7 @@ export function mapGeneralAMCQuestionnaireToInitialFormState(
                 ],
             },
             {
-                title: "Public sector",
+                title: "Shortages in public sector",
                 id: "public_sector_section",
                 isVisible: true,
                 required: true,
@@ -201,7 +201,7 @@ export function mapGeneralAMCQuestionnaireToInitialFormState(
                 ],
             },
             {
-                title: "Private sector",
+                title: "Shortages in private sector",
                 id: "private_sector_section",
                 isVisible: true,
                 required: true,
@@ -252,7 +252,7 @@ export function mapGeneralAMCQuestionnaireToInitialFormState(
                 ],
             },
             {
-                title: "AM class",
+                title: "Antimicrobial classes reported",
                 id: "am_class_section",
                 isVisible: true,
                 required: true,


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** https://app.clickup.com/t/8699n9max


It would also be nice to understand why we have the ids of the optionSets hard coded in the system. This change was needed because we needed to use a new multi-choice optionSet but we still need to make changes in the code for this. 
