### PR TITLE
feat: add AMR-I validations

### DIFF
--- a/src/domain/usecases/data-entry/amr-individual-fungal/RISIndividualFungalFileValidations.ts
+++ b/src/domain/usecases/data-entry/amr-individual-fungal/RISIndividualFungalFileValidations.ts
@@ -1,0 +1,55 @@
+import moment from "moment";
+import { CustomDataColumns } from "../../../entities/data-entry/amr-individual-fungal-external/RISIndividualFungalData";
+
+enum RISIndividualFungalFileColumns {
+    COUNTRY = "COUNTRY",
+    YEAR = "YEAR",
+    ADMISSION_DATE = "DATEOFHOSPITALISATION_VISIT",
+    SPECIMEN_DATE = "SAMPLE_DATE",
+}
+
+/** COUNTRY in each row must be the same as the selected org unit */
+export function checkCountry(dataItem: CustomDataColumns, orgUnit: string): string | null {
+    const countryValue = dataItem.find(item => item.key === RISIndividualFungalFileColumns.COUNTRY)?.value;
+    if (countryValue !== orgUnit) {
+        return `Country is different: Selected Data Submission Country : ${orgUnit}, Country in file: ${countryValue}`;
+    }
+    return null;
+}
+
+/** YEAR in each row must be the same as the selected period*/
+export function checkPeriod(dataItem: CustomDataColumns, period: string): string | null {
+    const yearValue = dataItem.find(item => item.key === RISIndividualFungalFileColumns.YEAR)?.value;
+    if (yearValue?.toString() !== period) {
+        return `Year is different: Selected Data Submission Year : ${period}, Year in file: ${yearValue}`;
+    }
+    return null;
+}
+
+/**  SAMPLE_DATE must have the same year as YEAR in the same row.
+ * If no SAMPLE_DATE is provided, it defaults to 01-01-period */
+export function checkSpecimenDate(dataItem: CustomDataColumns, period: string): string | null {
+    const specimenDateValue =
+        dataItem.find(item => item.key === RISIndividualFungalFileColumns.SPECIMEN_DATE)?.value || `01-01-${period}`;
+    const yearValue = dataItem.find(item => item.key === RISIndividualFungalFileColumns.YEAR)?.value;
+    if (moment(specimenDateValue).year().toString() !== yearValue?.toString()) {
+        return `${RISIndividualFungalFileColumns.SPECIMEN_DATE} year is different from ${RISIndividualFungalFileColumns.YEAR}: Specimen date is: ${specimenDateValue}, Year in file: ${yearValue}`;
+    }
+    return null;
+}
+
+/** DATEOFHOSPITALISATION_VISIT cannot be prior to 2016, and must be before SPECIMEN_DATE */
+export function checkAdmissionDate(dataItem: CustomDataColumns): string | null {
+    const MIN_ADMISSION_DATE = "2016-01-01";
+    const admissionDateValue = dataItem.find(item => item.key === RISIndividualFungalFileColumns.ADMISSION_DATE)?.value;
+    const specimenDateValue = dataItem.find(item => item.key === RISIndividualFungalFileColumns.SPECIMEN_DATE)?.value;
+    if (admissionDateValue) {
+        if (moment(admissionDateValue).isBefore(MIN_ADMISSION_DATE)) {
+            return `${RISIndividualFungalFileColumns.ADMISSION_DATE} cannot be prior to ${MIN_ADMISSION_DATE}: ${admissionDateValue}`;
+        }
+        if (moment(admissionDateValue).isAfter(moment(specimenDateValue))) {
+            return `${RISIndividualFungalFileColumns.ADMISSION_DATE} cannot be after ${RISIndividualFungalFileColumns.SPECIMEN_DATE}: Admission Date: ${admissionDateValue}, Specimen Date: ${specimenDateValue}`;
+        }
+    }
+    return null;
+}

--- a/src/domain/usecases/data-entry/amr-individual-fungal/RISIndividualFungalFileValidations.ts
+++ b/src/domain/usecases/data-entry/amr-individual-fungal/RISIndividualFungalFileValidations.ts
@@ -33,7 +33,9 @@ export function checkSpecimenDate(dataItem: CustomDataColumns, period: string): 
         dataItem.find(item => item.key === RISIndividualFungalFileColumns.SPECIMEN_DATE)?.value || `01-01-${period}`;
     const yearValue = dataItem.find(item => item.key === RISIndividualFungalFileColumns.YEAR)?.value;
     if (moment(specimenDateValue).year().toString() !== yearValue?.toString()) {
-        return `${RISIndividualFungalFileColumns.SPECIMEN_DATE} year is different from ${RISIndividualFungalFileColumns.YEAR}: Specimen date is: ${specimenDateValue}, Year in file: ${yearValue}`;
+        return `${RISIndividualFungalFileColumns.SPECIMEN_DATE} year is different from ${
+            RISIndividualFungalFileColumns.YEAR
+        }: Specimen date is: ${moment(specimenDateValue).format("YYYY-MM-DD")}, Year in file: ${yearValue}`;
     }
     return null;
 }
@@ -45,10 +47,16 @@ export function checkAdmissionDate(dataItem: CustomDataColumns): string | null {
     const specimenDateValue = dataItem.find(item => item.key === RISIndividualFungalFileColumns.SPECIMEN_DATE)?.value;
     if (admissionDateValue) {
         if (moment(admissionDateValue).isBefore(MIN_ADMISSION_DATE)) {
-            return `${RISIndividualFungalFileColumns.ADMISSION_DATE} cannot be prior to ${MIN_ADMISSION_DATE}: ${admissionDateValue}`;
+            return `${RISIndividualFungalFileColumns.ADMISSION_DATE} cannot be prior to ${MIN_ADMISSION_DATE}: ${moment(
+                admissionDateValue
+            ).format("YYYY-MM-DD")}`;
         }
         if (moment(admissionDateValue).isAfter(moment(specimenDateValue))) {
-            return `${RISIndividualFungalFileColumns.ADMISSION_DATE} cannot be after ${RISIndividualFungalFileColumns.SPECIMEN_DATE}: Admission Date: ${admissionDateValue}, Specimen Date: ${specimenDateValue}`;
+            return `${RISIndividualFungalFileColumns.ADMISSION_DATE} cannot be after ${
+                RISIndividualFungalFileColumns.SPECIMEN_DATE
+            }: Admission Date: ${moment(admissionDateValue).format("YYYY-MM-DD")}, Specimen Date: ${moment(
+                specimenDateValue
+            ).format("YYYY-MM-DD")}`;
         }
     }
     return null;


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8699n7b1g #8699n7b1g

### :memo: Implementation

- add `checkSpecimenDate` and `checkAdmissionDate`
- refactor: move individual row validations to `RISIndividualFungalFileValidations.ts` to avoid creating a summary for each validation type

This PR includes only the validations, but realized that `CustomDataColumns["value"]`  is typed as `string | number | undefined` even though it contains `Date` objects in case the column contains a date value. Also types are not enforced because of usage of `any` in `getProgramMetadata`, called from `common.ts`. We might want to improve this, specially if we find any date-related issues.

### :video_camera: Screenshots/Screen capture

![imagen](https://github.com/user-attachments/assets/b7b5aa13-9387-444e-b473-de9d35100f4f)

### :fire: Testing
