### PR TITLE
fix: check period for Product Data upload

### DIFF
--- a/src/domain/usecases/data-entry/amc/CustomValidationsAMCProductData.ts
+++ b/src/domain/usecases/data-entry/amc/CustomValidationsAMCProductData.ts
@@ -117,6 +117,7 @@ export class CustomValidationsAMCProductData {
         const errors = _(
             teis.map(tei => {
                 const curErrors = [];
+                // enrolledAt string format is "2023-01-01T00:00"
                 const eventDate = tei.enrollments?.[0]?.enrolledAt
                     ? new Date(tei.enrollments?.[0].enrolledAt)
                     : new Date();
@@ -139,7 +140,7 @@ export class CustomValidationsAMCProductData {
                         line: tei.trackedEntity ? parseInt(tei.trackedEntity) + 6 : -1,
                     });
                 }
-                if (eventDate.getUTCFullYear().toString() !== period) {
+                if (eventDate.getFullYear().toString() !== period) {
                     curErrors.push({
                         error: i18n.t(
                             `Event date is incorrect: Selected period : ${period}, date in file: ${


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #?

### :memo: Implementation

- There was an incorrect validation error when trying to upload AMC Product Level Data for Date `2023-01-01` for the period `2023`.
- This bug was introduced by #342 
- The change introduced by that PR was correct in the case of Substance Level Data (`CustomValidationForEventProgram`)
  - In this case, the source date string is in format `YYYY-MM-DD`.
- But for Product Level Data (`CustomValidationsAMCProductData`)  the change was reverted back to use `getFullYear`, since the source date string is in format `YYYY-MM-DDTHH:mm`.

```js
// CustomValidationForEventProgram
// event.ocurredAt is in format `YYYY-MM-DD`
// const eventDate = new Date(event.occurredAt);
new Date("2023-01-01").getFullYear() === 2022; // this is true for GMT < 0 TZs
new Date("2023-01-01").getFullYear() === 2023; // this is true for GMT >= 0 TZs
// here the fix was to use getUTCFullYear() since it will return 2023 in any TZ, since the date is assumed to be UTC
new Date("2023-01-01").getUTCFullYear() === 2023; // true for any TZ

// CustomValidationsAMCProductData
// tei.enrollments?.[0].enrolledAt is in format `YYYY-MM-DDTHH:mm`
// new Date(tei.enrollments?.[0].enrolledAt)
new Date("2023-01-01T00:00").getUTCFullYear() === 2023;  // true for GMT <= 0 TZs
new Date("2023-01-01T00:00").getUTCFullYear() === 2022;  // true for GMT > 0 TZs
// because time is provided, date it is created in local timezone
new Date("2023-01-01T00:00").getFullYear() === 2023; // this is true for any TZ
```


### :video_camera: Screenshots/Screen capture

### :fire: Testing
