### PR TITLE
BLOCKING AMR-I RIS upload error

### DIFF
--- a/src/data/repositories/GlassDocumentsDefaultRepository.ts
+++ b/src/data/repositories/GlassDocumentsDefaultRepository.ts
@@ -47,14 +47,18 @@ export class GlassDocumentsDefaultRepository implements GlassDocumentsRepository
                 })
             ),
             this.dataStoreClient.listCollection<GlassDocuments>(DataStoreKeys.DOCUMENTS)
-        ).flatMap(([fileUploadResult, documents]: [FileUploadResult, GlassDocuments[]]) => {
-            return this.saveSharingSettingsAndNewDocument(
-                fileUploadResult.id,
-                fileUploadResult.fileResourceId,
-                documents,
-                module
-            );
-        });
+        )
+            .flatMapError((error: unknown) => {
+                return Future.error(typeof error === "string" ? error : "Error while saving file");
+            })
+            .flatMap(([fileUploadResult, documents]: [FileUploadResult, GlassDocuments[]]) => {
+                return this.saveSharingSettingsAndNewDocument(
+                    fileUploadResult.id,
+                    fileUploadResult.fileResourceId,
+                    documents,
+                    module
+                );
+            });
     }
 
     saveBuffer(fileBuffer: Buffer, fileName: string, module: string): FutureData<string> {

--- a/src/webapp/components/current-data-submission/UploadsTableBody.tsx
+++ b/src/webapp/components/current-data-submission/UploadsTableBody.tsx
@@ -755,7 +755,10 @@ export const UploadsTableBody: React.FC<UploadsTableBodyProps> = ({
                                             }}
                                             disabled={
                                                 !hasCurrentUserCaptureAccess ||
-                                                !isEditModeStatus(currentDataSubmissionStatus.data.title)
+                                                !isEditModeStatus(currentDataSubmissionStatus.data.title) ||
+                                                isAlreadyMarkedToBeDeleted(row) ||
+                                                isCurrentlyBeingUploadedAsync(row) ||
+                                                hasErrorAsyncDeleting(row)
                                             }
                                         >
                                             <CheckCircleOutline />

--- a/src/webapp/components/upload/UploadPrimaryFile.tsx
+++ b/src/webapp/components/upload/UploadPrimaryFile.tsx
@@ -103,8 +103,9 @@ export const UploadPrimaryFile: React.FC<UploadPrimaryFileProps> = ({
                                         localStorage.setItem("primaryUploadId", uploadId);
                                         setIsLoading(false);
                                     },
-                                    () => {
-                                        snackbar.error(i18n.t("Error in file upload"));
+                                    error => {
+                                        console.error(`Error in file upload: ${error}`);
+                                        snackbar.error(i18n.t(`Error in file upload: ${error}`));
                                         setIsLoading(false);
                                     }
                                 );

--- a/src/webapp/components/upload/UploadSecondary.tsx
+++ b/src/webapp/components/upload/UploadSecondary.tsx
@@ -104,8 +104,9 @@ export const UploadSecondary: React.FC<UploadSecondaryProps> = ({
                                         setIsLoading(false);
                                         setHasSecondaryFile(true);
                                     },
-                                    () => {
-                                        snackbar.error(i18n.t("Error in file upload"));
+                                    error => {
+                                        console.error(`Error in file upload: ${error}`);
+                                        snackbar.error(i18n.t(`Error in file upload: ${error}`));
                                         setIsLoading(false);
                                     }
                                 );


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #8699wradu [BLOCKING AMR-I RIS upload error](https://app.clickup.com/t/8699wradu)

### :memo: Implementation
- Show error message if save file fails, disable continue button if async upload is enabled and the needed upload ids are missing
-  EXTRA: Fix do not allow to complete dataset if it is marked for being deleted

### :video_camera: Screenshots/Screen capture
Error explanation:

[Error_explanation.webm](https://github.com/user-attachments/assets/14d73970-7674-480f-bade-6ff344c70547)


Error message if file is larger than the configured DHIS2 maximum upload file size:

<img width="1852" height="894" alt="Error_if_larger_file" src="https://github.com/user-attachments/assets/48c40e01-4369-4690-9d82-484f39b9b021" />


### :fire: Testing
[WHO GLASS individual RIS.csv](https://github.com/user-attachments/files/21365144/WHO.GLASS.individual.RIS.csv)

In dev the DHIS2 maximum upload file size is configured as 10MB and this file has 12MB so this error will be displayed:

<img width="1501" height="923" alt="Screenshot from 2025-07-22 12-15-33" src="https://github.com/user-attachments/assets/93bfeac8-e2f0-4fce-826c-11ef611e04a4" />

If this is also the case on the client server, perhaps we can increase the maximum size of the file resources?