### PR TITLE
fix: make Selector widgets items display below the control

### DIFF
--- a/src/webapp/components/form/widgets/MultipleSelector.tsx
+++ b/src/webapp/components/form/widgets/MultipleSelector.tsx
@@ -71,6 +71,17 @@ export function MultipleSelector<Value extends string>({
                 variant="outlined"
                 IconComponent={IconChevronDown24}
                 error={error}
+                MenuProps={{
+                    anchorOrigin: {
+                        vertical: "bottom",
+                        horizontal: "left",
+                    },
+                    transformOrigin: {
+                        vertical: "top",
+                        horizontal: "left",
+                    },
+                    getContentAnchorEl: null,
+                }}
                 renderValue={(selected: unknown) =>
                     (selected as Value[])?.length ? (
                         <SelectedContainer>
@@ -134,6 +145,7 @@ const StyledSelect = styled(Select)<{ error?: boolean; disabled?: boolean }>`
         padding-inline-start: 12px;
         padding-inline-end: 6px;
         padding-block: 1px;
+        min-height: 38px;
         &:focus {
         }
         background-color: ${({ disabled }) => (disabled ? palette.background.default : "inherit")};
@@ -158,4 +170,5 @@ const SelectedContainer = styled.div`
     display: flex;
     flex-wrap: wrap;
     gap: 5px;
+    margin-block: 5px;
 `;

--- a/src/webapp/components/form/widgets/Selector.tsx
+++ b/src/webapp/components/form/widgets/Selector.tsx
@@ -79,6 +79,18 @@ export function Selector<Value extends string>({
                 variant="outlined"
                 IconComponent={IconChevronDown24}
                 error={error}
+                MenuProps={{
+                    anchorOrigin: {
+                        vertical: "bottom",
+                        horizontal: "left",
+                    },
+                    transformOrigin: {
+                        vertical: "top",
+                        horizontal: "left",
+                    },
+                    getContentAnchorEl: null,
+                    style: { marginTop: 2 },
+                }}
                 renderValue={(selected: unknown) => {
                     const value = getLabelFromValue(selected as Value, options);
                     if (value) {


### PR DESCRIPTION

### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8699yqck9 #8699yqck9

### :memo: Implementation

- Set popover properties, based on this comment: `https://github.com/mui/material-ui/issues/12208#issuecomment-406820537`
- Minor manual adjustments to margin and min-height for improved visual layout

Notes:  
- When there is no room below the dropdown, the items will accomodate to the viewport and may show above the dropdown
  - Tried different approaches to always show the menu below, but I couldn't find an easy way to accomplish that, and I think these changes are a good tradeoff. Let me know if we still want to do that.
- I tried setting a `maxHeight` for the menuItems, but finally discarded it.
  - For the number of options we are handling we are ok
  - Using `maxHeight` worsens the UX because the scroll isn't obvious and could be misleading. We may need to add a visual indicator if we want to add it.

### :video_camera: Screenshots/Screen capture

#### Before:
[Selects-before.webm](https://github.com/user-attachments/assets/d5e1221e-9419-414f-8832-b642fd9aeb57)

#### After:
[Selects-after.webm](https://github.com/user-attachments/assets/4ac8194d-55ff-48e6-8cfd-aaf3faa862d9)

### :fire: Testing
