### PR TITLE
[FIX] recalculate AMC data only when the recalculate flag is enabled

### DIFF
--- a/src/scripts/cliAMC.ts
+++ b/src/scripts/cliAMC.ts
@@ -69,7 +69,7 @@ async function main() {
                         )} and orgUnitsIds=${recalculateDataInfo?.orgUnitsIds.join(",")}`
                     );
 
-                    if (recalculateDataInfo) {
+                    if (recalculateDataInfo && recalculateDataInfo.recalculate) {
                         logger.info(
                             `[${new Date().toISOString()}] Disabling AMC recalculations before start with calculations`
                         );


### PR DESCRIPTION
### :pushpin: References

- Related to bug introduced in https://github.com/EyeSeeTea/glass-dev/pull/359

-   **Issue:** Closes #869e8q5v8 [869e8q5v8](https://app.clickup.com/t/4528615/869e8q5v8)

### :memo: Implementation

The recalculation cron gate was changed from `recalculateDataInfo && recalculateDataInfo.recalculate` to just `recalculateDataInfo` in PR #359 (commit c45a10ec). Since the amc-recalculation datastore object is persistent (disableRecalculations only sets recalculate=false, keeping periods/orgUnits, and nothing ever deletes the key), the object exists permanently after the first request. As a result every scheduled crontab run triggered a full recalculation of all stored periods and org units regardless of whether one was requested. Restore the flag check so recalculation runs only when explicitly enabled.


### :video_camera: Screenshots/Screen capture

### :fire: Testing
yarn start-amc-recalculate --auth "USER:PASSWORD" --url URL

